### PR TITLE
RDK-56229: Add IUI version as mandatory field

### DIFF
--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <ctype.h>
 
+#include <pthread.h>
 #include <cjson/cJSON.h>
 
 #include "dcalist.h"

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -25,7 +25,6 @@
 #include <unistd.h>
 #include <ctype.h>
 
-#include <pthread.h>
 #include <cjson/cJSON.h>
 
 #include "dcalist.h"

--- a/source/t2parser/t2parserxconf.c
+++ b/source/t2parser/t2parserxconf.c
@@ -216,6 +216,7 @@ T2ERROR processConfigurationXConf(char* configData, ProfileXConf **localProfile)
         addParameter(profile, "PartnerId", TR181_DEVICE_PARTNER_ID, NULL, -1);
         addParameter(profile, "Version", TR181_DEVICE_FW_VERSION, NULL, -1);
         addParameter(profile, "AccountId", TR181_DEVICE_ACCOUNT_ID, NULL, -1);
+        addParameter(profile, "immui_ver_split", TR181_IUI_VERSION, NULL, -1);
     }
     free(paramValue);
     paramValue = NULL;
@@ -229,6 +230,7 @@ T2ERROR processConfigurationXConf(char* configData, ProfileXConf **localProfile)
     addParameter(profile, "camIpv6", TR181_DEVICE_WAN_IPv6, NULL, -1);
 #else
     addParameter(profile, "StbIp", TR181_DEVICE_WAN_IPv6, NULL, -1);
+    addParameter(profile, "immui_ver_split", TR181_IUI_VERSION, NULL, -1);
 #endif
     addParameter(profile, "PartnerId", TR181_DEVICE_PARTNER_ID, NULL, -1);
     addParameter(profile, "Version", TR181_DEVICE_FW_VERSION, NULL, -1);

--- a/source/xconf-client/xconfclient.h
+++ b/source/xconf-client/xconfclient.h
@@ -80,6 +80,7 @@
 #define TR181_DEVICE_WAN_IPv6                       "Device.DeviceInfo.X_COMCAST-COM_STB_IP"
 #define TR181_DEVICE_CM_MAC                         "Device.DeviceInfo.X_COMCAST-COM_STB_MAC" 
 #define TR181_DEVICE_CM_IP                          "Device.DeviceInfo.X_COMCAST-COM_STB_IP"
+#define TR181_IUI_VERSION                           "Device.DeviceInfo.X_RDKCENTRAL-COM.IUI.Version"
 
 #endif // ENABLE_RDKB_SUPPORT
 


### PR DESCRIPTION
Reason for change: Include IUI version as mandatory field for video platforms
Test Procedure: Ensure all messgaes for legacy XCONF based profile includes field for IUI version for video
Risks: Low

Change-Id: Idffd01d5679aae4df7b602bea116decb5607ac38