### PR TITLE
RDKB-58931: Removing RFC control for non-root processes

### DIFF
--- a/source/bulkdata/reportprofiles.c
+++ b/source/bulkdata/reportprofiles.c
@@ -99,20 +99,11 @@ static void drop_root()
 {
     appcaps.caps = NULL;
     appcaps.user_name = NULL;
-    bool ret = false;
-    ret = isBlocklisted();
-    if(ret) 
-    {
-       T2Info("NonRoot feature is disabled\n");
-    }
-    else 
-    {
-       T2Info("NonRoot feature is enabled, dropping root privileges for Telemetry 2.0 Process\n");
-       init_capability();
-       drop_root_caps(&appcaps);
-       if(update_process_caps(&appcaps) != -1)//CID 281096: Unchecked return value (CHECKED_RETURN)
-       read_capability(&appcaps);
-    }
+    T2Info("NonRoot feature is enabled, dropping root privileges for Telemetry 2.0 Process\n");
+    init_capability();
+    drop_root_caps(&appcaps);
+    if(update_process_caps(&appcaps) != -1)//CID 281096: Unchecked return value (CHECKED_RETURN)
+    read_capability(&appcaps);
 }
 #endif
 


### PR DESCRIPTION
Reason for change: Wanmanager processes are running in non-root with rfc control, removing rfc controlled code part 
Test Procedure: Processes should not be able to switch back to root using RFC  DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.NonRootSupport.Blocklist 
Risks: Medium
Priority: P1