### PR TITLE
RDKB-55880 : Touch Flag to indicate XCONF report generation

### DIFF
--- a/source/bulkdata/profilexconf.c
+++ b/source/bulkdata/profilexconf.c
@@ -231,6 +231,9 @@ static void* CollectAndReportXconf(void* data)
                 encodeGrepResultInJSON(valArray, grepResultList);
                 Vector_Destroy(grepResultList, freeGResult);
             }
+
+	    dcaFlagReportCompleation();
+
             if(profile->eMarkerList != NULL && Vector_Size(profile->eMarkerList) > 0)
             {
                 encodeEventMarkersInJSON(valArray, profile->eMarkerList);

--- a/source/dcautil/dcautil.c
+++ b/source/dcautil/dcautil.c
@@ -57,3 +57,15 @@ void removeGrepConfig(char* profileName, bool clearSeekMap, bool clearExecMap) {
     T2Debug("%s ++out\n", __FUNCTION__);
 }
 
+// dcaFlagReportCompleation this function is used to create legacy DCA Flag DCADONEFLAG
+void dcaFlagReportCompleation(){
+	T2Debug("%s --in creating flag %s\n", __FUNCTION__,DCADONEFLAG);
+	FILE *fileCheck = fopen(DCADONEFLAG, "w+");
+	if (fileCheck == NULL ){
+		T2Error(" Error in creating the Flag :  %s\n",DCADONEFLAG);
+	}
+	else{
+		fclose(fileCheck);
+	}
+	T2Debug("%s --out\n", __FUNCTION__);
+}

--- a/source/dcautil/dcautil.h
+++ b/source/dcautil/dcautil.h
@@ -25,6 +25,7 @@
 #include "vector.h"
 
 #define TOPTEMP "/tmp/.t2toplog"
+#define DCADONEFLAG "/tmp/.dca_done"
 
 typedef struct _GrepResult
 {
@@ -68,4 +69,6 @@ int getMemInfo(procMemCpuInfo *pmInfo);
 int getCPUInfo(procMemCpuInfo *pInfo);
 int getProcPidStat(int pid, procinfo * pinfo);
 int getTotalCpuTimes(int * totalTime);
+
+void dcaFlagReportCompleation();
 #endif /* _DCAUTIL_H_ */

--- a/source/scheduler/scheduler.c
+++ b/source/scheduler/scheduler.c
@@ -569,7 +569,7 @@ T2ERROR unregisterProfileFromScheduler(const char* profileName)
             sched_yield(); // This will give chance for the signal receiving thread to start
             int count = 0;
             while(signalrecived_and_executing && !is_delete_on_timed_out){
-                if(count++ > 30){
+                if(count++ > 10){
                     break;
                 }
                 sleep(1);

--- a/source/scheduler/scheduler.c
+++ b/source/scheduler/scheduler.c
@@ -198,7 +198,6 @@ void* TimeoutThread(void *arg)
              notifySchedulerstartcb(tProfile->name, true);
              T2Info("Waiting for %d sec for next TIMEOUT for profile as firstreporting interval is given - %s\n", tProfile->firstreportint, tProfile->name);
              n = pthread_cond_timedwait(&tProfile->tCond, &tProfile->tMutex, &_ts);
-	     signalrecived_and_executing = false;
         }
         else{
              if(tProfile->timeOutDuration == UINT_MAX && tProfile->timeRefinSec == 0){
@@ -221,6 +220,7 @@ void* TimeoutThread(void *arg)
         {
             /* CID 175316:- Value not atomically updated (ATOMICITY) */
             T2Info("Interrupted before TIMEOUT for profile : %s \n", tProfile->name);
+            signalrecived_and_executing = false;
             if(minThresholdTime) 
             {
                  memset(&_MinThresholdTimeTs, 0, sizeof(struct timespec));
@@ -557,8 +557,8 @@ T2ERROR unregisterProfileFromScheduler(const char* profileName)
 		return T2ERROR_FAILURE;
 	    }
             tProfile->terminated = true;
+            signalrecived_and_executing = true;
             pthread_cond_signal(&tProfile->tCond);
-	    signalrecived_and_executing = true;
             if(pthread_mutex_unlock(&tProfile->tMutex) != 0){
                 T2Error("tProfile Mutex unlock failed\n");
                 pthread_mutex_unlock(&scMutex);


### PR DESCRIPTION
Reason for change: Similar to legacy DCA indicate report generation
  status with flag
Test Procedure: Check the "/tmp/.dca_done" after xconf report upload Risks: Low

RDKB-59084: Add caltimeout function for Webconfig

Reason for change: webconfig is canciling the T2 thread
  after default timeout, but the time to apply new config
  depends on profiles currently in the device.
Test Procedure: webconfig should wait for timeout and
  check no NACK is sent when applying new config.
Risks: Medium