### PR TITLE
RDK-56834 : Add Previous logs lookup feature in T2

### DIFF
--- a/include/telemetry2_0.h
+++ b/include/telemetry2_0.h
@@ -51,6 +51,9 @@ extern "C" {
 #define T2_DCM_START_CONFIG   "dcmStartConfig"
 #endif
 
+#define BOOTFLAG "/tmp/.t2bootup"
+//#define TOUCH_BOOTFLAG "touch "BOOTFLAG
+
 #define INFINITE_TIMEOUT      (unsigned int)~0
 
 #define T2_RP       0

--- a/source/bulkdata/profile.c
+++ b/source/bulkdata/profile.c
@@ -420,6 +420,7 @@ static void* CollectAndReport(void* data)
                     cJSON_AddItemToArray(valArray, arrayItem);
                     customLogPath = PREVIOUS_LOGS_PATH;
                     profile->bClearSeekMap = true;
+                    T2Debug("Adding Previous Logs Header to JSON report\n");
                 }
 #endif
                 if(profile->staticParamList != NULL && Vector_Size(profile->staticParamList) > 0)
@@ -439,7 +440,6 @@ static void* CollectAndReport(void* data)
                 }
                 if(profile->gMarkerList != NULL && Vector_Size(profile->gMarkerList) > 0)
                 {
-                    printf("custom path = %s\n", customLogPath);
                     getGrepResults(profile->name, profile->gMarkerList, &grepResultList, profile->bClearSeekMap, false, customLogPath); // Passing 5th argument as false so that it doesn't check rotated logs for the first reporting after bootup for multiprofiles.
                     encodeGrepResultInJSON(valArray, grepResultList);
                     Vector_Destroy(grepResultList, freeGResult);

--- a/source/bulkdata/profile.h
+++ b/source/bulkdata/profile.h
@@ -47,6 +47,8 @@ typedef struct _Profile
     bool generateNow;
     bool deleteonTimeout;
     bool bClearSeekMap;
+    bool checkPreviousSeek; // To support Previous_Logs report post reboot
+    bool saveSeekConfig; // To save the Seek config to persistant storage
     bool triggerReportOnCondition;
     bool trim;
     void (*callBackOnReportGenerationComplete)(char*);
@@ -88,7 +90,7 @@ typedef struct _Profile
     bool threadExists;
 } Profile;
 
-T2ERROR initProfileList();
+T2ERROR initProfileList(bool checkPreviousSeek);
 
 T2ERROR uninitProfileList();
 

--- a/source/bulkdata/profilexconf.c
+++ b/source/bulkdata/profilexconf.c
@@ -246,6 +246,7 @@ static void* CollectAndReportXconf(void* data)
                 customLogPath = PREVIOUS_LOGS_PATH;
                 profile->bClearSeekMap = true;
                 checkRotated = false;
+                T2Debug("Adding Previous Logs Header to JSON report\n");
             }
 #endif
 

--- a/source/bulkdata/profilexconf.h
+++ b/source/bulkdata/profilexconf.h
@@ -49,6 +49,8 @@ typedef struct _ProfileXConf
     bool isUpdated;
     bool reportInProgress;
     bool bClearSeekMap;
+    bool checkPreviousSeek; // To support Previous_Logs report post reboot
+    bool saveSeekConfig; // To save the Seek config to persistant storage
     char* name;
     char* protocol;
     char* encodingType;
@@ -64,7 +66,7 @@ typedef struct _ProfileXConf
     pthread_t reportThread;
 } ProfileXConf;
 
-T2ERROR ProfileXConf_init();
+T2ERROR ProfileXConf_init(bool checkPreviousSeek);
 T2ERROR ProfileXConf_uninit();
 T2ERROR ProfileXConf_set(ProfileXConf *profile);
 T2ERROR ProfileXConf_delete(ProfileXConf *profile);

--- a/source/bulkdata/reportprofiles.h
+++ b/source/bulkdata/reportprofiles.h
@@ -100,7 +100,7 @@ struct __msgpack__
     int msgpack_blob_size;
 };
 
-int __ReportProfiles_ProcessReportProfilesMsgPackBlob(void *msgpack);
+int __ReportProfiles_ProcessReportProfilesMsgPackBlob(void *msgpack, bool checkPreviousSeek);
 
 void ReportProfiles_ProcessReportProfilesMsgPackBlob(char *msgpack_blob, int msgpack_blob_size);
 

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -962,7 +962,7 @@ int getDCAResultsInJson(char* profileName, void* markerList, cJSON** grepResultL
 }
 
 
-int getDCAResultsInVector(char* profileName, Vector* vecMarkerList, Vector** grepResultList, bool check_rotated)
+int getDCAResultsInVector(char* profileName, Vector* vecMarkerList, Vector** grepResultList, bool check_rotated, char* customLogPath)
 {
 
     T2Debug("%s ++in \n", __FUNCTION__);
@@ -982,10 +982,19 @@ int getDCAResultsInVector(char* profileName, Vector* vecMarkerList, Vector** gre
             initProperties(logPath, persistentPath);
         }
 
+        if (customLogPath)
+        {
+            initProperties(customLogPath, persistentPath);
+        }
+
         Vector_Create(grepResultList);
         if( (rc = parseMarkerList(profileName, vecMarkerList, *grepResultList, check_rotated)) == -1 )
         {
             T2Debug("Error in fetching grep results\n");
+        }
+        if (customLogPath)
+        {
+            initProperties(logPath, persistentPath);
         }
     }
     pthread_mutex_unlock(&dcaMutex);

--- a/source/dcautil/dca.h
+++ b/source/dcautil/dca.h
@@ -27,7 +27,7 @@
  */
 int getDCAResultsInJson(char* profileName, void* vectorMarkerList, cJSON** grepResultList);
 
-int getDCAResultsInVector(char* profileName, Vector* vectorMarkerList, Vector** grepResultList, bool check_rotated);
+int getDCAResultsInVector(char* profileName, Vector* vectorMarkerList, Vector** grepResultList, bool check_rotated, char* customLogPath);
 
 char *strSplit(char *str, char *delim);
 

--- a/source/dcautil/dcautil.c
+++ b/source/dcautil/dcautil.c
@@ -26,11 +26,11 @@
 #include "t2log_wrapper.h"
 #include "t2common.h"
 #include "legacyutils.h"
-
+#include "persistence.h"
 
 
 T2ERROR
-getGrepResults (char *profileName, Vector *markerList, Vector **grepResultList, bool isClearSeekMap, bool check_rotated)
+getGrepResults (char *profileName, Vector *markerList, Vector **grepResultList, bool isClearSeekMap, bool check_rotated, char *customLogPath)
 {
     T2Debug("%s ++in\n", __FUNCTION__);
     if(profileName == NULL || markerList == NULL || grepResultList == NULL)
@@ -39,7 +39,7 @@ getGrepResults (char *profileName, Vector *markerList, Vector **grepResultList, 
         return T2ERROR_FAILURE;
     }
 
-    getDCAResultsInVector(profileName, markerList, grepResultList, check_rotated);
+    getDCAResultsInVector(profileName, markerList, grepResultList, check_rotated, customLogPath);
     if (isClearSeekMap)
     {
         removeProfileFromSeekMap(profileName);
@@ -79,4 +79,136 @@ void dcaFlagReportCompleation()
         fclose(fileCheck);
     }
     T2Debug("%s --out\n", __FUNCTION__);
+}
+
+# ifdef PERSIST_LOG_MON_REF
+T2ERROR saveSeekConfigtoFile(char* profileName)
+{
+    T2Debug("%s ++in\n", __FUNCTION__);
+    if(profileName == NULL)
+    {
+        T2Error("Profile Name is not available\n");
+        return T2ERROR_FAILURE;
+    }
+    GrepSeekProfile *ProfileSeekMap = getLogSeekMapForProfile(profileName);
+    if(ProfileSeekMap == NULL)
+    {
+        T2Error("ProfileSeekMap is NULL\n");
+        return T2ERROR_FAILURE;
+    }
+    hash_map_t *logfileMap = ProfileSeekMap->logFileSeekMap;
+    if(logfileMap == NULL)
+    {
+        T2Error("logfileMap is NULL\n");
+        return T2ERROR_FAILURE;
+    }
+
+    unsigned int count = (unsigned int) hash_map_count(logfileMap);
+
+    cJSON *valArray = cJSON_CreateArray();
+    for (unsigned int i = 0; i < count ; i++)
+    {
+        char *logFileName = NULL;
+        long *seekvalue = NULL;
+        logFileName = hash_map_lookupKey(logfileMap, i);
+        seekvalue = hash_map_lookup(logfileMap, i);
+        cJSON *logFileObj = cJSON_CreateObject();
+        cJSON_AddNumberToObject(logFileObj, logFileName, (double)*seekvalue);
+        cJSON_AddItemToArray(valArray, logFileObj);
+    }
+    char *jsonReport = cJSON_PrintUnformatted(valArray);
+    if(T2ERROR_SUCCESS != saveConfigToFile(SEEKFOLDER, profileName, jsonReport))
+    {
+        T2Error("Failed to save config to file\n");
+        cJSON_Delete(valArray);
+        free(jsonReport);
+        return T2ERROR_FAILURE;
+    }
+    T2Debug("%s --out\n", __FUNCTION__);
+    return T2ERROR_SUCCESS;
+}
+
+T2ERROR loadSavedSeekConfig(char *profileName)
+{
+    T2Debug("%s ++in\n", __FUNCTION__);
+
+    if(profileName == NULL)
+    {
+        T2Error("Profile Name is not available\n");
+        return T2ERROR_FAILURE;
+    }
+    int len = strlen(profileName) + strlen(SEEKFOLDER) + 2;
+    char *seekFile = (char *)malloc(len);
+    snprintf(seekFile, len, "%s/%s", SEEKFOLDER, profileName);
+    FILE *file = fopen(seekFile, "rb");
+    if(file == NULL)
+    {
+        T2Error("Failed to open file\n");
+        free(seekFile);
+        return T2ERROR_FAILURE;
+    }
+    fseek(file, 0, SEEK_END);
+    long fileSize = ftell(file);
+    fseek(file, 0, SEEK_SET);
+
+    char *data = malloc(fileSize + 1);
+    if (data == NULL)
+    {
+        T2Error("Memory allocation failed\n");
+        fclose(file);
+        return T2ERROR_FAILURE;
+    }
+    fread(data, 1, fileSize, file);
+    fclose(file);
+    data[fileSize] = '\0';
+    cJSON *json = cJSON_Parse(data);
+    cJSON *item = NULL;
+    GrepSeekProfile *ProfileSeekMap = NULL;
+    ProfileSeekMap = (GrepSeekProfile *) getLogSeekMapForProfile(profileName);
+    if (ProfileSeekMap == NULL)
+    {
+        ProfileSeekMap = (GrepSeekProfile *) addToProfileSeekMap(profileName);
+    }
+    cJSON_ArrayForEach(item, json)
+    {
+        // Each `item` is an object in the array
+        if (item->child != NULL)
+        {
+            const char *key = item->child->string;
+            cJSON *value = item->child;
+
+            if (key != NULL)
+            {
+                // Check the value type and print it
+                if (cJSON_IsNumber(value))
+                {
+                    long *tempnum;
+                    double val = value->valuedouble;
+                    tempnum = (long *)malloc(sizeof(long));
+                    *tempnum = (long)val;
+                    hash_map_put(ProfileSeekMap->logFileSeekMap, strdup(key), tempnum, NULL);
+                    //printf("Key: %s, Value: %ld\n", key, *tempnum);
+                }
+            }
+
+        }
+    }
+    cJSON_Delete(json);
+    free(data);
+    free(seekFile);
+    return T2ERROR_SUCCESS;
+    T2Debug("%s --out\n", __FUNCTION__);
+}
+#endif
+
+bool firstBootStatus()
+{
+    T2Debug("%s ++in\n", __FUNCTION__);
+    bool status = true;
+    if(access(BOOTFLAG, F_OK) != -1)
+    {
+        status = false;
+    }
+    T2Debug("%s --out\n", __FUNCTION__);
+    return status;
 }

--- a/source/dcautil/dcautil.h
+++ b/source/dcautil/dcautil.h
@@ -27,6 +27,10 @@
 #define TOPTEMP "/tmp/.t2toplog"
 #define DCADONEFLAG "/tmp/.dca_done"
 
+#define PREVIOUS_LOG "PREVIOUS_LOG"
+#define PREVIOUS_LOGS_VAL  "1"
+#define PREVIOUS_LOGS_PATH "/opt/logs/PreviousLogs/"
+
 typedef struct _GrepResult
 {
     const char* markerName;
@@ -43,7 +47,7 @@ void removeTopOutput();
 void removeGrepConfig(char* profileName, bool clearSeek, bool clearExec);
 void freeGResult(void *data);
 T2ERROR saveGrepConfig(char *name, Vector* grepMarkerList);
-T2ERROR getGrepResults(char* profileName, Vector *markerList, Vector **grepResultList, bool isClearSeekMap, bool check_rotated);
+T2ERROR getGrepResults(char* profileName, Vector *markerList, Vector **grepResultList, bool isClearSeekMap, bool check_rotated, char *customLogPath);
 #define PREFIX_SIZE 5
 #define BUF_LEN 16
 
@@ -71,6 +75,14 @@ int getMemInfo(procMemCpuInfo *pmInfo);
 int getCPUInfo(procMemCpuInfo *pInfo);
 int getProcPidStat(int pid, procinfo * pinfo);
 int getTotalCpuTimes(int * totalTime);
+
+
+#ifdef PERSIST_LOG_MON_REF
+typedef void (*freeconfigdata)(void *data);
+T2ERROR saveSeekConfigtoFile(char* profileName);
+T2ERROR loadSavedSeekConfig(char *profileName);
+bool firstBootStatus();
+#endif
 
 void dcaFlagReportCompleation();
 #endif /* _DCAUTIL_H_ */

--- a/source/dcautil/legacyutils.c
+++ b/source/dcautil/legacyutils.c
@@ -581,6 +581,7 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                             if(NULL != rotatedLog)
                             {
                                 rotatedLog[-1] = '1';
+                                //T2Debug("Log file name seems to be having .0 extension hence Rotated log file name is %s\n", rotatedLog);
                             }
                         }
                         else
@@ -589,6 +590,7 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                             if(NULL != rotatedLog)
                             {
                                 snprintf(rotatedLog, fileExtn_len, "%s%s%s", logpath, name, fileExtn);
+                                //T2Debug("Rotated log file name is %s\n", rotatedLog);
                             }
                         }
                         if(NULL != rotatedLog)
@@ -636,16 +638,16 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                 }
                 else
                 {
-                    if(currentLogFile != NULL)
-                    {
-                        free(currentLogFile);
-                    }
                     if((NULL != DEVICE_TYPE) && (0 == strcmp("broadband", DEVICE_TYPE)))
                     {
                         T2Debug("Telemetry file pointer corrupted");
                         if(fseek(pcurrentLogFile, 0, 0) != 0)
                         {
                             T2Error("Cannot set the file position indicator for the stream pointed to by stream\n");
+                        }
+                        if(currentLogFile != NULL)
+                        {
+                            free(currentLogFile);
                         }
                     }
                     else
@@ -658,6 +660,7 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                             if(NULL != rotatedLog)
                             {
                                 rotatedLog[-1] = '1';
+                                //T2Debug("Log file name seems to be having .0 extension hence Rotated log file name is %s\n", rotatedLog);
                             }
                         }
                         else
@@ -666,7 +669,12 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                             if(NULL != rotatedLog)
                             {
                                 snprintf(rotatedLog, fileExtn_len, "%s%s%s", logpath, name, fileExtn);
+                                //T2Debug("Rotated log file name is %s\n", rotatedLog);
                             }
+                        }
+                        if(currentLogFile != NULL)
+                        {
+                            free(currentLogFile);
                         }
 
                         if(NULL != rotatedLog)

--- a/source/dcautil/legacyutils.c
+++ b/source/dcautil/legacyutils.c
@@ -519,7 +519,6 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
         T2Debug("Invalid arguments or NULL arguments\n");
         return NULL;
     }
-
     char *logpath = LOG_PATH;
 
     /* If name is already an absolute path then prepend empty string instead of LOG_PATH */
@@ -574,11 +573,26 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                 {
                     if(check_rotated_logs)  // considering the rotated log file  within few minutes after bootup, it should check only for the first time
                     {
-                        char * rotatedLog = malloc(fileExtn_len);
+                        char * rotatedLog;
+                        size_t name_len = strlen(currentLogFile);
+                        if(name_len > 2 && currentLogFile[name_len - 2] == '.' && currentLogFile[name_len - 1] == '0')
+                        {
+                            rotatedLog = strdup(currentLogFile);
+                            if(NULL != rotatedLog)
+                            {
+                                rotatedLog[-1] = '1';
+                            }
+                        }
+                        else
+                        {
+                            rotatedLog = malloc(fileExtn_len);
+                            if(NULL != rotatedLog)
+                            {
+                                snprintf(rotatedLog, fileExtn_len, "%s%s%s", logpath, name, fileExtn);
+                            }
+                        }
                         if(NULL != rotatedLog)
                         {
-                            snprintf(rotatedLog, fileExtn_len, "%s%s%s", logpath, name, fileExtn);
-
                             fclose(pcurrentLogFile);
                             pcurrentLogFile = NULL;
                             pcurrentLogFile = fopen(rotatedLog, "rb");
@@ -636,12 +650,27 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                     }
                     else
                     {
-                        char * rotatedLog = malloc(fileExtn_len);
+                        char * rotatedLog;
+                        size_t name_len = strlen(currentLogFile);
+                        if(name_len > 2 && currentLogFile[name_len - 2] == '.' && currentLogFile[name_len - 1] == '0')
+                        {
+                            rotatedLog = strdup(currentLogFile);
+                            if(NULL != rotatedLog)
+                            {
+                                rotatedLog[-1] = '1';
+                            }
+                        }
+                        else
+                        {
+                            rotatedLog = malloc(fileExtn_len);
+                            if(NULL != rotatedLog)
+                            {
+                                snprintf(rotatedLog, fileExtn_len, "%s%s%s", logpath, name, fileExtn);
+                            }
+                        }
 
                         if(NULL != rotatedLog)
                         {
-                            snprintf(rotatedLog, fileExtn_len, "%s%s%s", logpath, name, fileExtn);
-
                             fclose(pcurrentLogFile);
                             pcurrentLogFile = NULL;
                             pcurrentLogFile = fopen(rotatedLog, "rb");

--- a/source/t2parser/t2parser.c
+++ b/source/t2parser/t2parser.c
@@ -354,6 +354,9 @@ static T2ERROR addParameter(Profile *profile, const char* name, const char* ref,
         gMarker->skipFreq = skipFreq;
         gMarker->firstSeekFromEOF = firstSeekFromEOF;
         Vector_PushBack(profile->gMarkerList, gMarker);
+#ifdef PERSIST_LOG_MON_REF
+        profile->saveSeekConfig = true;
+#endif
     }
 
     profile->paramNumOfEntries++;
@@ -1348,6 +1351,8 @@ T2ERROR processConfiguration(char** configData, char *profileName, char* profile
     profile->maxUploadLatency = 0;
     profile->timeRef = NULL;
     profile->isSchedulerstarted = false;
+    profile->saveSeekConfig = false;
+    profile->checkPreviousSeek = false;
     if(jprofileDeleteOnTimeout)
     {
         profile->deleteonTimeout = (cJSON_IsTrue(jprofileDeleteOnTimeout) == 1);
@@ -2433,6 +2438,8 @@ T2ERROR processMsgPackConfiguration(msgpack_object *profiles_array_map, Profile 
     profile->maxUploadLatency = 0;
     profile->timeRef = NULL;
     profile->isSchedulerstarted = false;
+    profile->saveSeekConfig = false;
+    profile->checkPreviousSeek = false;
 
     DeleteOnTimout_boolean = msgpack_get_map_value(value_map, "DeleteOnTimeout");
     msgpack_print(DeleteOnTimout_boolean, msgpack_get_obj_name(DeleteOnTimeout_boolean));

--- a/source/t2parser/t2parserxconf.c
+++ b/source/t2parser/t2parserxconf.c
@@ -326,6 +326,14 @@ T2ERROR processConfigurationXConf(char* configData, ProfileXConf **localProfile)
 
     cJSON_Delete(json_root);
 
+#ifdef PERSIST_LOG_MON_REF
+    profile->saveSeekConfig = true;
+    profile->checkPreviousSeek = false;
+#else
+    profile->saveSeekConfig = false;
+    profile->checkPreviousSeek = false;
+#endif
+
     *localProfile = profile;
 
     T2Debug("%s --out\n", __FUNCTION__);

--- a/source/utils/persistence.h
+++ b/source/utils/persistence.h
@@ -44,6 +44,10 @@
 
 #define CACHED_MESSAGE_PATH PERSISTENCE_PATH"/.t2cachedmessages/"
 
+#ifdef PERSIST_LOG_MON_REF
+#define SEEKFOLDER PERSISTENCE_PATH"/.t2seekmap/"
+#endif
+
 typedef struct _Config
 {
     char* name;


### PR DESCRIPTION
Reason for change: To add previous logs lookup in par with T1 DCA
Test Procedure: No regression, lookup feature should be working as expected
Risks: Low
Signed-off-by: c.shivabhaskar97@gmail.com