### PR TITLE
RDKEMW-3107 : [DELIA-67415, RDKB-57595]Fix Race condition in uninit sequence, Clear the init flags first during uninit

### DIFF
--- a/source/scheduler/scheduler.c
+++ b/source/scheduler/scheduler.c
@@ -473,8 +473,8 @@ void uninitScheduler()
         //pthread_join(tProfile->tId, NULL); // pthread_detach in freeSchedulerProfile will detach the thread
         T2Info("Profile %s successfully removed from Scheduler\n", tProfile->name);
     }
-    Vector_Destroy(profileList, freeSchedulerProfile);
-    profileList = NULL;
+    // Vector_Destroy(profileList, freeSchedulerProfile); This is not needed here as we will clear
+    // profileList = NULL; the structure from unregisterProfileFromScheduler from TimeoutThread
     if(pthread_mutex_unlock(&scMutex) != 0)
     {
         T2Error("scMutex unlock failed\n");

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -102,14 +102,6 @@ T2ERROR initTelemetry()
 
 static void terminate()
 {
-    if (initcomplete)
-    {
-#ifndef DEVICE_EXTENDER
-        uninitXConfClient();
-#endif
-        ReportProfiles_uninit();
-    }
-
     if(remove("/tmp/.t2ReadyToReceiveEvents") != 0)
     {
         printf("removing the file /tmp/.t2ReadyToReceiveEvents failed!\n");
@@ -124,6 +116,14 @@ static void terminate()
     {
         printf("removing the file T2_CONFIG_READY failed!\n");
     }
+    if (initcomplete)
+    {
+#ifndef DEVICE_EXTENDER
+        uninitXConfClient();
+#endif
+        ReportProfiles_uninit();
+    }
+
 }
 static void _print_stack_backtrace(void)
 {

--- a/telemetry2_0.service
+++ b/telemetry2_0.service
@@ -25,6 +25,7 @@ Requires=network-online.target
 Type=forking
 ExecStart=/usr/bin/telemetry2_0
 ExecStop=/usr/bin/killall telemetry2_0
+ExecStopPost=/bin/rm -rf /tmp/.t2ReadyToReceiveEvents /tmp/telemetry_initialized_bootup /tmp/.t2ConfigReady
 Restart=always
 
 [Install]


### PR DESCRIPTION
Reason for change: Deleting the structure in uninitScheduler is breaking
 the code in the TimeoutThread as both functions are referencing same
 structure
Test Procedure: There should be no crash when rebooting the device Risks: Low

RDKB-57595 : Clear the init flags first during uninit

Reason for change: During uninit clear the flags first, these are
  left if the uninit is taking more time creating issues in next init
Test Procedure: check flags after T2 un init the flags should be cleared Risks: Low