### PR TITLE
RDKB-59420: Minor update to Previous Logs lookup feature

### DIFF
--- a/source/bulkdata/profile.c
+++ b/source/bulkdata/profile.c
@@ -1379,6 +1379,15 @@ static void loadReportProfilesFromDisk(bool checkPreviousSeek)
                 }
                 else
                 {
+
+#ifdef PERSIST_LOG_MON_REF
+                    if(profile->checkPreviousSeek)
+                    {
+                        T2Info("Previous Seek is enabled so generate the report for %s\n", profile->name);
+                        // Trigger the report generation for the profile if previous seek is valid
+                        NotifyTimeout(profile->name, true);
+                    }
+#endif
                     // Load the cached messages from previous boot, if any
                     populateCachedReportList(profile->name, profile->cachedReportList);
                 }

--- a/source/bulkdata/profilexconf.c
+++ b/source/bulkdata/profilexconf.c
@@ -512,6 +512,15 @@ T2ERROR ProfileXConf_init(bool checkPreviousSeek)
                 if(T2ERROR_SUCCESS == ProfileXConf_set(profile))
                 {
                     T2Info("Successfully set new profile: %s\n", profile->name);
+
+#ifdef PERSIST_LOG_MON_REF
+                    if(profile->checkPreviousSeek)
+                    {
+                        T2Info("Previous Seek is enabled so generate the Xconf report \n");
+                        // Trigger a xconf report if previous seek is enabled and valid.
+                        ProfileXConf_notifyTimeout(true, true);
+                    }
+#endif
                     populateCachedReportList(profile->name, profile->cachedReportList);
                 }
                 else

--- a/source/bulkdata/reportprofiles.c
+++ b/source/bulkdata/reportprofiles.c
@@ -615,18 +615,6 @@ T2ERROR initReportProfiles()
         }
     }
 
-#ifdef PERSIST_LOG_MON_REF
-
-    if(previousLogCheck)
-    {
-        //generate previous logs report
-        generateDcaReport(false, false);
-        T2Info("Previous Log check is enabled sending Interrupt to scheduler \n");
-        sendLogUploadInterruptToScheduler();
-    }
-#endif
-
-
     if(ProfileXConf_isSet() || getProfileCount() > 0)
     {
 
@@ -1386,6 +1374,8 @@ int __ReportProfiles_ProcessReportProfilesMsgPackBlob(void *msgpack, bool checkP
                 {
                     T2Info("Previous seek is enabled for profile %s \n", profile->name);
                     profile->checkPreviousSeek = true;
+                    T2Info("Previous Seek is enabled so generate the report for %s\n", profile->name);
+                    NotifyTimeout(profile->name, true);
                 }
                 else
                 {

--- a/source/ccspinterface/rbusInterface.c
+++ b/source/ccspinterface/rbusInterface.c
@@ -1356,7 +1356,7 @@ void unregisterDEforCompEventList()
 
     if(!compTr181ParamMap)
     {
-        T2Info("No data elements present to unregister");
+        T2Info("No data elements present to unregister\n");
         T2Debug("%s --out\n", __FUNCTION__);
         pthread_mutex_unlock(&compParamMap);
         return;

--- a/source/dcautil/legacyutils.c
+++ b/source/dcautil/legacyutils.c
@@ -580,8 +580,8 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                             rotatedLog = strdup(currentLogFile);
                             if(NULL != rotatedLog)
                             {
-                                rotatedLog[-1] = '1';
-                                //T2Debug("Log file name seems to be having .0 extension hence Rotated log file name is %s\n", rotatedLog);
+                                rotatedLog[name_len - 1] = '1';
+                                T2Debug("Log file name seems to be having .0 extension hence Rotated log file name is %s\n", rotatedLog);
                             }
                         }
                         else
@@ -590,7 +590,7 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                             if(NULL != rotatedLog)
                             {
                                 snprintf(rotatedLog, fileExtn_len, "%s%s%s", logpath, name, fileExtn);
-                                //T2Debug("Rotated log file name is %s\n", rotatedLog);
+                                T2Debug("Rotated log file name is %s\n", rotatedLog);
                             }
                         }
                         if(NULL != rotatedLog)
@@ -659,8 +659,8 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                             rotatedLog = strdup(currentLogFile);
                             if(NULL != rotatedLog)
                             {
-                                rotatedLog[-1] = '1';
-                                //T2Debug("Log file name seems to be having .0 extension hence Rotated log file name is %s\n", rotatedLog);
+                                rotatedLog[name_len - 1] = '1';
+                                T2Debug("Log file name seems to be having .0 extension hence Rotated log file name is %s\n", rotatedLog);
                             }
                         }
                         else
@@ -669,7 +669,7 @@ char *getLogLine(hash_map_t *logSeekMap, char *buf, int buflen, char *name, int 
                             if(NULL != rotatedLog)
                             {
                                 snprintf(rotatedLog, fileExtn_len, "%s%s%s", logpath, name, fileExtn);
-                                //T2Debug("Rotated log file name is %s\n", rotatedLog);
+                                T2Debug("Rotated log file name is %s\n", rotatedLog);
                             }
                         }
                         if(currentLogFile != NULL)


### PR DESCRIPTION
Reason for change: Fix syntax error and logic to report generation during previous seek
Test Procedure: There should not be any regression.
Risks: Low