### PR TITLE
RDKB-59616: Default to MTLS connection on all endpoints

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -210,7 +210,7 @@ AM_CONDITIONAL([IS_LIBRDKCERTSEL_ENABLED], [test x$IS_LIBRDKCERTSEL_ENABLED = xt
 AC_SUBST(LIBRDKCERTSEL_FLAG)
 
 AC_ARG_ENABLE([mtls],
-        AS_HELP_STRING([--enable-mtls], [Enable mTLS support (default is yes)]),
+        AS_HELP_STRING([--enable-mtls], [Enable mTLS support (default is no)]),
         [
           case "${enableval}" in
            yes) IS_MTLS_ENABLED=true
@@ -219,11 +219,7 @@ AC_ARG_ENABLE([mtls],
           *) AC_MSG_ERROR([bad value ${enableval} for --enable-mtls]) ;;
           esac
         ],
-        [
-          IS_MTLS_ENABLED=true
-          MTLS_FLAG=" -DENABLE_MTLS "
-        ])
-
+        [echo "MTLS is disabled"])
 AM_CONDITIONAL([IS_MTLS_ENABLED], [test x$IS_MTLS_ENABLED = xtrue])
 AC_SUBST(MTLS_FLAG)
 

--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,7 @@ LIBSYSWRAPPER_FLAG=" "
 IS_LIBSYSWRAPPER_ENABLED=" "
 IS_LIBRDKCONFIG_ENABLED=" "
 IS_LIBRDKCERTSEL_ENABLED=" "
+IS_MTLS_ENABLED=" "
 
 AC_ARG_ENABLE([gtestapp],
              AS_HELP_STRING([--enable-gtestapp],[enable Gtest support (default is no)]),
@@ -207,6 +208,24 @@ AC_ARG_ENABLE([rdkcertselector],
         [echo "rdkcertselector is disabled"])
 AM_CONDITIONAL([IS_LIBRDKCERTSEL_ENABLED], [test x$IS_LIBRDKCERTSEL_ENABLED = xtrue])
 AC_SUBST(LIBRDKCERTSEL_FLAG)
+
+AC_ARG_ENABLE([mtls],
+        AS_HELP_STRING([--enable-mtls], [Enable mTLS support (default is yes)]),
+        [
+          case "${enableval}" in
+           yes) IS_MTLS_ENABLED=true
+                MTLS_FLAG=" -DENABLE_MTLS ";;
+           no)  IS_MTLS_ENABLED=false ;;
+          *) AC_MSG_ERROR([bad value ${enableval} for --enable-mtls]) ;;
+          esac
+        ],
+        [
+          IS_MTLS_ENABLED=true
+          MTLS_FLAG=" -DENABLE_MTLS "
+        ])
+
+AM_CONDITIONAL([IS_MTLS_ENABLED], [test x$IS_MTLS_ENABLED = xtrue])
+AC_SUBST(MTLS_FLAG)
 
 AC_CONFIG_FILES([Makefile
                  source/Makefile

--- a/include/telemetry2_0.h
+++ b/include/telemetry2_0.h
@@ -37,7 +37,6 @@ extern "C" {
 #define T2_TEMP_REPORT_PROFILE_PARAM "Device.X_RDKCENTRAL-COM_T2.Temp_ReportProfiles"
 #define T2_TOTAL_MEM_USAGE "Device.X_RDK_T2.TotalUsedMem"
 
-#define T2_MTLS_RFC "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.MTLS.Enable"
 #define PRIVACYMODES_RFC "Device.X_RDKCENTRAL-COM_Privacy.PrivacyMode"
 #define T2_ON_DEMAND_REPORT "Device.X_RDKCENTRAL-COM_T2.UploadDCMReport"
 #define T2_ABORT_ON_DEMAND_REPORT "Device.X_RDKCENTRAL-COM_T2.AbortDCMReport"

--- a/source/bulkdata/Makefile.am
+++ b/source/bulkdata/Makefile.am
@@ -61,3 +61,7 @@ endif
 if IS_LIBRDKCERTSEL_ENABLED
 libbulkdata_la_CFLAGS = $(LIBRDKCERTSEL_FLAG)
 endif
+
+if IS_MTLS_ENABLED
+libbulkdata_la_CFLAGS = $(MTLS_FLAG)
+endif

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -34,7 +34,9 @@
 
 #include "curlinterface.h"
 #include "reportprofiles.h"
+#ifdef ENABLE_MTLS
 #include "t2MtlsUtils.h"
+#endif
 #include "t2log_wrapper.h"
 #include "busInterface.h"
 #ifdef LIBRDKCERTSEL_BUILD

--- a/source/utils/Makefile.am
+++ b/source/utils/Makefile.am
@@ -34,6 +34,7 @@ endif
 
 if IS_MTLS_ENABLED
 libt2utils_la_CFLAGS = $(MTLS_FLAG)
+libt2utils_la_SOURCES += t2MtlsUtils.c
 endif
 
 if RDKLOGGER_ENABLE

--- a/source/utils/Makefile.am
+++ b/source/utils/Makefile.am
@@ -19,7 +19,7 @@
 AM_CFLAGS = -fno-permissive
 lib_LTLIBRARIES = libt2utils.la
 
-libt2utils_la_SOURCES = vector.c t2collection.c t2log_wrapper.c t2MtlsUtils.c persistence.c t2common.c
+libt2utils_la_SOURCES = vector.c t2collection.c t2log_wrapper.c persistence.c t2common.c
 libt2utils_la_LDFLAGS = -shared -fPIC
 libt2utils_la_CFLAGS = -DUNUSED
 

--- a/source/utils/Makefile.am
+++ b/source/utils/Makefile.am
@@ -32,6 +32,10 @@ libt2utils_la_CFLAGS += $(LIBSYSWRAPPER_FLAG)
 libt2utils_la_LDFLAGS += -lsecure_wrapper
 endif
 
+if IS_MTLS_ENABLED
+libt2utils_la_CFLAGS = $(MTLS_FLAG)
+endif
+
 if RDKLOGGER_ENABLE
 libt2utils_la_CFLAGS += -DRDK_LOGGER 
 libt2utils_la_LDFLAGS += -lrdkloggers

--- a/source/utils/t2MtlsUtils.c
+++ b/source/utils/t2MtlsUtils.c
@@ -16,8 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#ifdef ENABLE_MTLS
 #include "t2MtlsUtils.h"
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/source/xconf-client/Makefile.am
+++ b/source/xconf-client/Makefile.am
@@ -26,6 +26,11 @@ if IS_LIBRDKCERTSEL_ENABLED
 libxconfclient_la_CFLAGS = $(LIBRDKCERTSEL_FLAG)
 libxconfclient_la_LDFLAGS += -lRdkCertSelector
 endif
+
+if IS_MTLS_ENABLED
+libxconfclient_CFLAGS = $(MTLS_FLAG)
+endif
+
 libxconfclient_la_LIBADD = ${top_builddir}/source/t2parser/libt2parser.la ${top_builddir}/source/ccspinterface/libccspinterface.la
 libxconfclient_la_CPPFLAGS = -fPIC -I${PKG_CONFIG_SYSROOT_DIR}$(includedir)/dbus-1.0 \
                                 -I${PKG_CONFIG_SYSROOT_DIR}$(libdir)/dbus-1.0/include \

--- a/source/xconf-client/xconfclient.c
+++ b/source/xconf-client/xconfclient.c
@@ -35,7 +35,9 @@
 #include "reportprofiles.h"
 #include "profilexconf.h"
 #include "xconfclient.h"
+#ifdef ENABLE_MTLS
 #include "t2MtlsUtils.h"
+#endif
 #include "t2parserxconf.h"
 #include "vector.h"
 #include "persistence.h"


### PR DESCRIPTION
Reason for change: Defaulting MTLS with build time flag and removed RFC
Test Procedure: As mentioned in ticket
Risks: Medium
Priority: P1