### PR TITLE
RDKBDEV-3174 T2 Telemetry JSON report incorrectly serializes all TR-181 parameter values as strings (missing type fidelity)

### DIFF
--- a/source/ccspinterface/busInterface.h
+++ b/source/ccspinterface/busInterface.h
@@ -28,10 +28,33 @@
 #define CCSP_COMPONENT_ID          "eRT.com.cisco.spvtg.ccsp.telemetry"
 #endif // CCSP_SUPPORT_ENABLED 
 
-typedef struct
+/**
+ * Enumeration of possible types for TR-181 values
+ */
+
+typedef enum {
+    TR181_TYPE_STRING,
+    TR181_TYPE_INT,
+    TR181_TYPE_UNSIGNED,
+    TR181_TYPE_BOOLEAN,
+    TR181_TYPE_DATETIME,
+    TR181_TYPE_BASE64,
+    TR181_TYPE_LONG,
+    TR181_TYPE_UNSIGNED_LONG,
+    TR181_TYPE_FLOAT,
+    TR181_TYPE_DOUBLE
+} TR181ParameterType;
+
+/**
+ * Structure containing the name and value of a TR-181 parameter,
+ * as well as its type (added for correct JSON encoding).
+ */
+
+typedef struct 
 {
     char *parameterName;
     char *parameterValue;
+    TR181ParameterType type;
 
 } tr181ValStruct_t;
 


### PR DESCRIPTION
 telemetry: Add tr 181 type tracking for CCSP/RBUS parameters

Introduced enum TR181ParameterType and added 'type' field to tr181ValStruct_t in businterface.h. Updated getCCSPProfileParamValues() and getRbusProfileParamValues() to map CCSP/RBUS value types to TR181ParameterType. Modified encodeParamResultInJSON() to inspect tr181ValStruct_t.type and use cJSON_AddNumberToObject, cJSON_AddBoolToObject or cJSON_AddStringToObject as appropriate. Added necessary includes (ccsp_memory.h, ccsp_base_api.h, rbus.h) and cleaned up resource handling (free_parameterValStruct_t, etc.). Ensures telemetry JSON output uses proper numeric/boolean types instead of quoting all values.

Signed-off-by: Abdelkarim EL HOSNI abdelkarim.elhosni.prestataire@sfr.com