### PR TITLE
RDK-57493:Run L2 test with device mgmt native platform container (#78)

### DIFF
--- a/.github/workflows/L2-tests.yml
+++ b/.github/workflows/L2-tests.yml
@@ -14,34 +14,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        
-      - name: Checkout telemetry code
+      - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          path : 'telemetry'
 
-      - name: Checkout rdk_logger 
-        uses: actions/checkout@v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          repository: 'rdkcentral/rdk_logger'
-          path : 'telemetry/containers/native-platform/rdk_logger'
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout WebconfigFramework 
-        uses: actions/checkout@v4
-        with:
-          repository: 'rdkcentral/WebconfigFramework'
-          path : 'telemetry/containers/native-platform/WebconfigFramework'
-
-      - name: InstallC astyle 
+      - name: Install C astyle
         run: |
-            sudo apt-get update
-            sudo apt-get install astyle -y
+          sudo apt-get update
+          sudo apt-get install astyle -y
 
       - name: Check for formatting errors
         run: |
-          cd telemetry
           find . -name '*.c' -o -name '*.h' | xargs astyle --options=.astylerc
           find . -name '*.orig' -type f -delete
           git diff --name-only --exit-code
@@ -54,62 +43,36 @@ jobs:
           else
             echo "Code formatting errors not found."
           fi
-          cd - 
- 
-      - name: Build Docker image for Mock XCONF Server
-        uses: docker/build-push-action@v4
-        with:
-          context: telemetry/containers/mock-xconf
-          push: false
-          tags: mock-xconf:latest
-          load: true
 
-      # - name: List Docker Images
-      # run: docker images
-      # commenting this as this was used in debugging to see if container loads with load: true
-
-      - name: Dump self-signed public serts from mock-xconf container
+      - name: Pull docker images
         run: |
-          docker run --rm mock-xconf:latest cat /etc/xconf/certs/mock-xconf-server-cert.pem >  telemetry/containers/native-platform/mock-xconf-server-cert.pem
+          docker pull ghcr.io/rdkcentral/docker-device-mgt-service-test/mockxconf:latest
+          docker pull ghcr.io/rdkcentral/docker-device-mgt-service-test/native-platform:latest
 
-      - name: Build Docker image for native platform Server
-        uses: docker/build-push-action@v4
-        with:
-          context: telemetry/containers/native-platform
-          push: false
-          tags: native-platform:latest
-          load: true
-
-      - name: Install Docker Compose
+      - name: Start mock-xconf service
         run: |
-          sudo apt-get update
-          sudo apt-get install docker-compose -y
+          docker run -d --name mockxconf -p 50050:50050 -p 50051:50051 -p 50052:50052 -v ${{ github.workspace }}:/mnt/L2_CONTAINER_SHARED_VOLUME ghcr.io/rdkcentral/docker-device-mgt-service-test/mockxconf:latest
 
-      - name: Run L2 container with code attached to /mnt/L2_CONTAINER_SHARED_VOLUME
+      - name: Start l2-container service
         run: |
-          cd telemetry/containers
-          docker-compose up -d 
+          docker run -d --name native-platform --link mockxconf -v ${{ github.workspace }}:/mnt/L2_CONTAINER_SHARED_VOLUME ghcr.io/rdkcentral/docker-device-mgt-service-test/native-platform:latest
 
-      - name: Run L2 tests in the native-platform container
+      - name: Enter Inside Platform native container and run L2 Test
         run: |
-          docker exec -i native-platform /bin/bash -c "cd /mnt/L2_CONTAINER_SHARED_VOLUME/ && sh build_inside_container.sh && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/lib/aarch64-linux-gnu:/usr/local/lib: &&  sh test/run_l2.sh"
-          
-      - name: Copy l2 test results to runner 
+          docker exec -i native-platform /bin/bash -c "cd /mnt/L2_CONTAINER_SHARED_VOLUME/ && sh build_inside_container.sh && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:/lib/aarch64-linux-gnu:/usr/local/lib: && sh test/run_l2.sh"
+
+      - name: Copy l2 test results to runner
         run: |
           docker cp native-platform:/tmp/l2_test_report /tmp/L2_TEST_RESULTS
-
-      - name: Shut down L2 container
-        run: |
-          cd telemetry/containers
-          docker-compose down
-
+          ls -l
+          ls -l /tmp/L2_TEST_RESULTS
   upload-test-results:
     name: Upload L2 test results to automatic test result management system
     needs: execute-L2-tests-on-pr
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rdkcentral/docker-rdk-ci:latest
-      volumes: 
+      volumes:
         - /tmp/L2_TEST_RESULTS:/tmp/L2_TEST_RESULTS
     steps:
       - name: Upload results
@@ -123,6 +86,3 @@ jobs:
             echo "==============================="
             git config --global --add safe.directory `pwd`
             gtest-json-result-push.py /tmp/L2_TEST_RESULTS https://rdkeorchestrationservice.apps.cloud.comcast.net/rdke_orchestration_api/push_unit_test_results `pwd`
-
- 
-

--- a/containers/compose.yaml
+++ b/containers/compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   mock-xconf:
-    image: "mock-xconf:latest"
+    image: "ghcr.io/rdkcentral/docker-device-mgt-service-test/mockxconf:latest"
     container_name: "mockxconf"
     ports:
       - "50050:50050"
@@ -11,7 +11,7 @@ services:
 
 
   l2-container:
-    image: "native-platform:latest"
+    image: "ghcr.io/rdkcentral/docker-device-mgt-service-test/native-platform"
     container_name: "native-platform"
     depends_on:
       - mock-xconf


### PR DESCRIPTION
* RDK-57495:Run L1 test cases

Reason for change: To run L1 mock test cases
Test Procedure: run L1 test cases
Risks: Medium
Priority: P1


* Revert "RDK-57495:Run L1 test cases"

This reverts commit 69323e0605d34d60e3b35e18c6a947be9f4a8ff4.

* RDK-57493:Run L2 test with device mgmt native platform container

Reason for change: To run L2 test with device management native-platform container
Test Procedure: run L2 test cases
Risks: Medium
Priority: P1

* Update compose.yaml

* Update L2-tests.yml

* Update L2-tests.yml

* RDK-57493: Reuse prebuilts containers

* RDK-57493: Reuse prebuilts containers

---------