### PR TITLE
RDK-57782: Add L2 test cases for telemetry

### DIFF
--- a/test/functional-tests/features/telemetry_process_multiprofile.feature
+++ b/test/functional-tests/features/telemetry_process_multiprofile.feature
@@ -164,4 +164,65 @@ Feature: Telemetry multiprofile configuration and report generation
     When a multiprofile is configured and a DCM profile is fetched from xconf
     Then both the multiprofile and the DCM profile should be enabled
     Then report should be generated for both the multiprofile and DCM profile separately
-    
+
+ Scenario: Multiprofile with timeref as default and maxUploadLatency & First reporting interval given 
+    Given When the telemetry daemon is already running
+    When a multiprofile is configured with timeref as default and maxUploadLatency given
+    Then  If first reporting interval is given, it will be taken for reporting. MaxUploadLatency won't be accepted
+    Then report should be generated according to first reporting interval if given or reporting interval if first reporting interval is not given.
+
+Scenario: Multiprofile with timeref is not default and maxUploadLatency & First reporting interval given
+    Given When the telemetry daemon is already running
+    When a multiprofile is configured with timeref as not default and maxUploadLatency given
+    Then  If first reporting interval is given, it won't be taken for reporting. MaxUploadLatency will be taken while sending the report to the cloud.
+    Then report should be generated according to reporting interval and it should be sent to the cloud after waiting for random value of maxlatency.
+
+Scenario: Multiprofile with  maxUploadLatency (millisec) greater than reporting interval (sec)
+    Given When the telemetry daemon is already running
+    When a multiprofile is configured with maxUploadLatency greater than reporting interval
+    Then  Multiprofile should be rejected logging the error message "Maxlatency is greater then reporting interval. Invalid Profile"
+
+Scenario: Multiprofile without parameters and Trigger Conditions
+    Given When the telemetry daemon is already running
+    When a multiprofile is configured without parameters and Trigger Conditions
+    Then Multiprofile should be rejected logging the error message "Incomplete Profile Information, unable to create profile"
+
+Scenario: Multiprofile having  TriggerCondition without type parameter
+    Given When the telemetry daemon is already running
+    When a multiprofile is configured with TriggerCondition without type parameter
+    Then Multiprofile should be rejected
+
+Scenario: Multiprofile having  TriggerCondition without reference parameter
+    Given When the telemetry daemon is already running
+    When a multiprofile is configured with TriggerCondition without reference parameter
+    Then Multiprofile should be rejected
+
+Scenario: Multiprofile having  TriggerCondition with Unexpected type parameter
+    Given When the telemetry daemon is already running
+    When a multiprofile is configured with TriggerCondition with unexpected type parameter
+    Then Multiprofile should be rejected
+
+Scenario: Multiprofile having  TriggerCondition without operator parameter
+    Given When the telemetry daemon is already running
+    When a multiprofile is configured with TriggerCondition without operator parameter
+    Then Multiprofile should be rejected
+
+Scenario: Multiprofile having  TriggerCondition with unexpected operator parameter
+    Given When the telemetry daemon is already running                                                     
+    When a multiprofile is configured with TriggerCondition with unexpected operator parameter
+    Then Multiprofile should be rejected
+
+Scenario: Multiprofile having  TriggerCondition with operator other then "any" without threshold  parameter
+    Given When the telemetry daemon is already running                                                     
+    When a multiprofile is configured with TriggerCondition with operator other then "any" without threshold parameter
+    Then Multiprofile should be rejected
+
+Scenario: Multiprofile having  TriggerCondition with unexpected reference parameter                         
+    Given When the telemetry daemon is already running                                                     
+    When a multiprofile is configured with TriggerCondition with unexpected reference parameter
+    Then Multiprofile should be rejected
+
+Scenario: Multiprofile with TriggerConditions                         
+    Given When the telemetry daemon is already running                                                     
+    When a multiprofile is configured with TriggerConditions
+    Then Multiprofile should be accepted and report should be generated whenever trigger condition is triggered

--- a/test/functional-tests/features/telemetry_xconf_communication.feature
+++ b/test/functional-tests/features/telemetry_xconf_communication.feature
@@ -48,3 +48,12 @@ Feature: Telemetry Xconf communication
     When the telemetry communicates with Xconf server
     Then the telemetry should respect the 404 error and not save any data
     Then telemetry should terminate all reporting based on xconf profiles and not attempt to communicate with xconf server
+
+   Scenario: Telemetry Xconf communication with valid URL check for logupload and logupload_on_demand
+   Given Paramater Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.ConfigURL is set to a valid https URL
+   When the telemetry binary is invoked or reload is initiated with signal reload
+   Then the telemetry should be running as a daemon
+   Then the telemetry should be communicating with Xconf server
+   When the telemetry communicates with Xconf server
+   Then the telemetry should be generating the report when it received the kill signal 10
+   Then the telemetry should be generating the report when it received the kill signal 29

--- a/test/functional-tests/tests/report_profiles.py
+++ b/test/functional-tests/tests/report_profiles.py
@@ -1,4 +1,8 @@
 
+data_empty_profile = '''{
+    "profiles": [{}]
+    }'''
+
 data_without_namefield = '''{
     "profiles": [
         {
@@ -413,7 +417,7 @@ data_with_wrong_protocol_value = '''{
                 "Protocol": "HTTP",
                 "EncodingType": "JSON",
                 "ActivationTimeout": 1200,
-                "ReportingInterval": 20,
+                "ReportingInterval": 10,
                 "GenerateNow": false,
                 "RootName": "FR2_US_TC3",
                 "TimeReference": "2023-01-25T13:47:00Z",
@@ -602,7 +606,7 @@ data_without_EncodingType_ActivationTimeout_values = '''{
                 "Protocol": "HTTP",
                 "EncodingType": "JSON",
                 "ActivationTimeout": "",
-                "ReportingInterval": 35,
+                "ReportingInterval": 15,
                 "GenerateNow": false,
                 "RootName": "FR2_US_TC3",
                 "TimeReference": "2023-01-25T13:47:00Z",
@@ -718,7 +722,7 @@ data_without_EncodingType_ActivationTimeout_values = '''{
                 "Version": "0.1",
                 "Protocol": "HTTP",
                 "EncodingType": "JSON",
-                "ReportingInterval": 35,
+                "ReportingInterval": 20,
                 "GenerateNow": false,
                 "RootName": "FR2_US_TC3",
                 "TimeReference": "2023-01-25T13:47:00Z",
@@ -835,7 +839,7 @@ data_without_EncodingType_ActivationTimeout_values = '''{
                 "Protocol": "HTTP",
                 "EncodingType": "JSON",
                 "ActivationTimeout": 3600,
-                "ReportingInterval": 45,
+                "ReportingInterval": 30,
                 "RootName": "FR2_US_TC3",
                 "TimeReference": "2023-01-25T13:47:00Z",
                 "Parameter": [
@@ -898,7 +902,7 @@ data_with_reporting_interval = '''{
                 "Protocol": "HTTP",
                 "EncodingType": "JSON",
                 "ActivationTimeout": 3600,
-                "ReportingInterval": 45,
+                "ReportingInterval": 20,
                 "GenerateNow": false,
                 "RootName": "FR2_US_TC3",
                 "Parameter": [
@@ -1323,4 +1327,774 @@ data_with_delete_on_timeout = '''{
         }
     ]
 }'''
+#json test cases
+#profile with timeref and first reporting Interval shouldn't be taken
+data_with_first_reporting_interval_neg = '''{
+    "profiles": [
+        {
+            "name": "NA_FRI",
+            "hash": "Hash89",
+            "value": {
+                "Name": "RDKB_FRI_Profile",
+                "Description": "RDKB_Profile",
+                "Version": "0.1",
+                "Protocol": "HTTP",
+                "EncodingType": "JSON",
+                "ActivationTimeOut": 30,
+                "DeleteOnTimeout": true,
+                "ReportingInterval": 10,
+                "GenerateNow": false,
+                "RootName": "FR2_US_TC3",
+                "TimeReference": "2023-01-25T13:47:00Z",
+                "Parameter": [
+                    {
+                        "type": "dataModel",
+                        "name": "MODEL_NAME",
+                        "reference": "Device.DeviceInfo.ModelName",
+                        "use": "absolute",
+                        "regex":"[A-Z]+"
+                    },
+                    {
+                        "type": "event",
+                        "eventName": "TEST_EVENT_MARKER_2",
+                        "component": "sysint",
+                        "use": "absolute",
+                        "regex":"[0-9]+"
+                    },
+                    {
+                        "type": "grep",
+                        "marker": "SYS_INFO_CrashPortalUpload_success",
+                        "search": "Success uploading",
+                        "logFile": "core_log.txt",
+                        "use": "absolute",
+                        "regex":"[0-9]+"
+                    }
+                ],
+                "ReportingAdjustments": 
+                    {
+                        "ReportOnUpdate": true,
+                        "FirstReportingInterval": 5,
+                        "MaxUploadLatency": 10
+                    },
+                "HTTP": {
+                    "URL": "https://mockxconf:50051/dataLakeMock/",
+                    "Compression": "None",
+                    "Method": "POST",
+                    "RequestURIParameter": [
+                        {
+                            "Name": "reportName",
+                            "Reference": "Profile.Name"
+                        }
+                    ]
+                },
+                "JSONEncoding": {
+                    "ReportFormat": "NameValuePair",
+                    "ReportTimestamp": "None"
+                }
+            }
+        },
 
+    ]
+}'''
+
+#profile with timeref default and max reporting interval shouldn't be taken
+data_with_maxuploadlatency_neg = '''{
+    "profiles": [
+        {
+            "name": "NA_MLU",
+            "hash": "Hash90",
+            "value": {
+                "Name": "RDKB_ML_Profile",
+                "Description": "RDKB_Profile",
+                "Version": "0.1",
+                "Protocol": "HTTP",
+                "EncodingType": "JSON",
+                "ActivationTimeOut": 20,
+                "DeleteOnTimeout": true,
+                "ReportingInterval": 10,
+                "GenerateNow": false,
+                "RootName": "FR2_US_TC3",
+                "TimeReference": "0001-01-01T00:00:00Z",
+                "Parameter": [
+                    {
+                        "type": "dataModel",
+                        "name": "MODEL_NAME",
+                        "reference": "Device.DeviceInfo.ModelName",
+                        "use": "absolute",
+                        "regex":"[A-Z]+"
+                    },
+                    {
+                        "type": "event",
+                        "eventName": "TEST_EVENT_MARKER_2",
+                        "component": "sysint",
+                        "use": "absolute",
+                        "regex":"[0-9]+"
+                    },
+                    {
+                        "type": "grep",
+                        "marker": "SYS_INFO_CrashPortalUpload_success",
+                        "search": "Success uploading",
+                        "logFile": "core_log.txt",
+                        "use": "absolute",
+                        "regex":"[0-9]+"
+                    }
+                ],
+                "ReportingAdjustments":
+                    {
+                        "ReportOnUpdate": true,
+                        "FirstReportingInterval": 5,
+                        "MaxUploadLatency": 10
+                    },
+                "HTTP": {
+                    "URL": "https://mockxconf:50051/dataLakeMock/",
+                    "Compression": "None",
+                    "Method": "POST",
+                    "RequestURIParameter": [
+                        {
+                            "Name": "reportName",
+                            "Reference": "Profile.Name"
+                        }
+                    ]
+                },
+                "JSONEncoding": {
+                    "ReportFormat": "NameValuePair",
+                    "ReportTimestamp": "None"
+                }
+            }
+        }
+    ]
+}'''
+
+data_with_first_reporting_interval_max_latency = '''{
+    "profiles": [
+        {
+            "name": "NA_FRI",
+            "hash": "Hash89",
+            "value": {
+                "Name": "RDKB_FRI_Profile",
+                "Description": "RDKB_Profile",
+                "Version": "0.1",
+                "Protocol": "HTTP",
+                "EncodingType": "JSON",
+                "ActivationTimeOut": 30,
+                "DeleteOnTimeout": true,
+                "ReportingInterval": 10,
+                "GenerateNow": false,
+                "RootName": "FR2_US_TC3",
+                "TimeReference": "2023-01-25T13:47:00Z",
+                "Parameter": [
+                    {
+                        "type": "dataModel",
+                        "name": "MODEL_NAME",
+                        "reference": "Device.DeviceInfo.ModelName",
+                        "use": "absolute",
+                        "regex":"[A-Z]+"
+                    },
+                    {
+                        "type": "event",
+                        "eventName": "TEST_EVENT_MARKER_2",
+                        "component": "sysint",
+                        "use": "absolute",
+                        "regex":"[0-9]+"
+                    },
+                    {
+                        "type": "grep",
+                        "marker": "SYS_INFO_CrashPortalUpload_success",
+                        "search": "Success uploading",
+                        "logFile": "core_log.txt",
+                        "use": "absolute",
+                        "regex":"[0-9]+"
+                    }
+                ],
+                "ReportingAdjustments":
+                    {
+                        "ReportOnUpdate": true,
+                        "FirstReportingInterval": 5,
+                        "MaxUploadLatency": 10
+                    },
+                "HTTP": {
+                    "URL": "https://mockxconf:50051/dataLakeMock/",
+                    "Compression": "None",
+                    "Method": "POST",
+                    "RequestURIParameter": [
+                        {
+                            "Name": "reportName",
+                            "Reference": "Profile.Name"
+                        }
+                    ]
+                },
+                "JSONEncoding": {
+                    "ReportFormat": "NameValuePair",
+                    "ReportTimestamp": "None"
+                }
+            }
+        },
+        {
+            "name": "NA_MLU",
+            "hash": "Hash90",
+            "value": {
+                "Name": "RDKB_ML_Profile",
+                "Description": "RDKB_Profile",
+                "Version": "0.1",
+                "Protocol": "HTTP",
+                "EncodingType": "JSON",
+                "ActivationTimeOut": 20,
+                "DeleteOnTimeout": true,
+                "ReportingInterval": 10,
+                "GenerateNow": false,
+                "RootName": "FR2_US_TC3",
+                "TimeReference": "0001-01-01T00:00:00Z",
+                "Parameter": [
+                    {
+                        "type": "dataModel",
+                        "name": "MODEL_NAME",
+                        "reference": "Device.DeviceInfo.ModelName",
+                        "use": "absolute",
+                        "regex":"[A-Z]+"
+                    },
+                    {
+                        "type": "event",
+                        "eventName": "TEST_EVENT_MARKER_2",
+                        "component": "sysint",
+                        "use": "absolute",
+                        "regex":"[0-9]+"
+                    },
+                    {
+                        "type": "grep",
+                        "marker": "SYS_INFO_CrashPortalUpload_success",
+                        "search": "Success uploading",
+                        "logFile": "core_log.txt",
+                        "use": "absolute",
+                        "regex":"[0-9]+"
+                    }
+                ],
+                "ReportingAdjustments":
+                    {
+                        "ReportOnUpdate": true,
+                        "FirstReportingInterval": 5,
+                        "MaxUploadLatency": 10
+                    },
+                "HTTP": {
+                    "URL": "https://mockxconf:50051/dataLakeMock/",
+                    "Compression": "None",
+                    "Method": "POST",
+                    "RequestURIParameter": [
+                        {
+                            "Name": "reportName",
+                            "Reference": "Profile.Name"
+                        }
+                    ]
+                },
+                "JSONEncoding": {
+                    "ReportFormat": "NameValuePair",
+                    "ReportTimestamp": "None"
+                }
+            }
+        },
+        {
+            "name": "NA_MLU_GT_RI",
+            "hash": "Hash91",
+            "value": {
+                "Name": "RDKB_ML_Profile",
+                "Description": "RDKB_Profile",
+                "Version": "0.1",
+                "Protocol": "HTTP",
+                "EncodingType": "JSON",
+                "ActivationTimeOut": 20,
+                "DeleteOnTimeout": true,
+                "ReportingInterval": 10,
+                "GenerateNow": false,
+                "RootName": "FR2_US_TC3",
+                "TimeReference": "2023-01-25T13:47:00Z",
+                "Parameter": [
+                    {
+                        "type": "dataModel",
+                        "name": "MODEL_NAME",
+                        "reference": "Device.DeviceInfo.ModelName",
+                        "use": "absolute",
+                        "regex":"[A-Z]+"
+                    },
+                    {
+                        "type": "event",
+                        "eventName": "TEST_EVENT_MARKER_2",
+                        "component": "sysint",
+                        "use": "absolute",
+                        "regex":"[0-9]+"
+                    },
+                    {
+                        "type": "grep",
+                        "marker": "SYS_INFO_CrashPortalUpload_success",
+                        "search": "Success uploading",
+                        "logFile": "core_log.txt",
+                        "use": "absolute",
+                        "regex":"[0-9]+"
+                    }
+                ],
+                "ReportingAdjustments":
+                    {
+                        "ReportOnUpdate": true,
+                        "FirstReportingInterval": 5,
+                        "MaxUploadLatency": 20000
+                    },
+                "HTTP": {
+                    "URL": "https://mockxconf:50051/dataLakeMock/",
+                    "Compression": "None",
+                    "Method": "POST",
+                    "RequestURIParameter": [
+                        {
+                            "Name": "reportName",
+                            "Reference": "Profile.Name"
+                        }
+                    ]
+                },
+                "JSONEncoding": {
+                    "ReportFormat": "NameValuePair",
+                    "ReportTimestamp": "None"
+                }
+            }
+        },
+        {
+            "name": "PARAM_NULL",
+            "hash": "Hash90",
+            "value": {
+                "Name": "RDKB_ML_Profile",
+                "Description": "RDKB_Profile",
+                "Version": "0.1",
+                "Protocol": "HTTP",
+                "EncodingType": "JSON",
+                "ActivationTimeOut": 20,
+                "DeleteOnTimeout": true,
+                "ReportingInterval": 10,
+                "GenerateNow": false,
+                "RootName": "FR2_US_TC3",
+                "TimeReference": "0001-01-01T00:00:00Z",
+                "Parameter": []
+                }
+        }
+    ]
+}'''
+
+#profile with timeref default and max reporting interval shouldn't be taken
+data_with_triggerconditon_neg = '''{
+    "profiles": [
+     {
+      "name": "TC_TYPE_NULL",
+      "hash": "Hash_Default",
+      "value": {
+        "Description": "Trigger condition type NULL case",
+        "Version": ".01",
+        "Protocol": "RBUS_METHOD",
+        "EncodingType": "JSON",
+        "GenerateNow": false,
+        "ReportingInterval": 10,
+        "ActivationTimeOut": 360,
+        "TimeReference": "0001-01-01T00:00:00Z",
+        "Parameter": [],
+        "TriggerCondition": [
+          {
+            "reference": "Device.X_RDK_WanManager.InterfaceAvailableStatus"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_WanManager.InterfaceActiveStatus"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_Remote.Device.2.Status"
+          }
+        ],
+        "RBUS_METHOD": {
+          "Method": "Device.X_RDK_Xmidt.SendData",
+          "Parameters": [
+            {
+              "name": "msg_type",
+              "value": "event"
+            },
+            {
+              "name": "source",
+              "value": "telemetry2"
+            },
+            {
+              "name": "dest",
+              "value": "event:/profile-report/LTE-report"
+            },
+            {
+              "name": "content_type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "JSONEncoding": {
+          "ReportFormat": "NameValuePair",
+          "ReportTimestamp": "None"
+        }
+      }
+    },
+    {
+      "name": "TC_REF_NULL",
+      "hash": "Hash_Default",
+      "value": {
+        "Description": "Trigger Condition Reference NULL case",
+        "Version": ".01",
+        "Protocol": "RBUS_METHOD",
+        "EncodingType": "JSON",
+        "GenerateNow": false,
+        "ReportingInterval": 10,
+        "ActivationTimeOut": 360,
+        "TimeReference": "0001-01-01T00:00:00Z",
+        "Parameter": [],
+        "TriggerCondition": [
+          {
+            "type": "dataModel",
+            "operator": "any"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_WanManager.InterfaceActiveStatus"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_Remote.Device.2.Status"
+          }
+        ],
+        "RBUS_METHOD": {
+          "Method": "Device.X_RDK_Xmidt.SendData",
+          "Parameters": [
+            {
+              "name": "msg_type",
+              "value": "event"
+            },
+            {
+              "name": "source",
+              "value": "telemetry2"
+            },
+            {
+              "name": "dest",
+              "value": "event:/profile-report/LTE-report"
+            },
+            {
+              "name": "content_type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "JSONEncoding": {
+          "ReportFormat": "NameValuePair",
+          "ReportTimestamp": "None"
+        }
+      }
+    },
+    {
+      "name": "TC_TYPE_NOT_DETAMODEL",
+      "hash": "Hash_Default",
+      "value": {
+        "Description": "Trigger Condition type is not datamodel",
+        "Version": ".01",
+        "Protocol": "RBUS_METHOD",
+        "EncodingType": "JSON",
+        "GenerateNow": false,
+        "ReportingInterval": 240,
+        "ActivationTimeOut": 360,
+        "TimeReference": "0001-01-01T00:00:00Z",
+        "Parameter": [],
+        "TriggerCondition": [
+          {
+            "type": "grep",
+            "reference": "Device.X_RDK_WanManager.InterfaceAvailableStatus"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_WanManager.InterfaceActiveStatus"
+          }
+        ],
+        "RBUS_METHOD": {
+          "Method": "Device.X_RDK_Xmidt.SendData",
+          "Parameters": [
+            {
+              "name": "msg_type",
+              "value": "event"
+            },
+            {
+              "name": "source",
+              "value": "telemetry2"
+            },
+            {
+              "name": "dest",
+              "value": "event:/profile-report/LTE-report"
+            },
+            {
+              "name": "content_type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "JSONEncoding": {
+          "ReportFormat": "NameValuePair",
+          "ReportTimestamp": "None"
+        }
+      }
+    },
+    {
+      "name": "TC_OPERATOR_NULL",
+      "hash": "Hash_Default",
+      "value": {
+        "Description": "Trigger condition operator is NULL",
+        "Version": ".01",
+        "Protocol": "RBUS_METHOD",
+        "EncodingType": "JSON",
+        "GenerateNow": false,
+        "ReportingInterval": 25,
+        "ActivationTimeOut": 360,
+        "TimeReference": "0001-01-01T00:00:00Z",
+        "Parameter": [],
+        "TriggerCondition": [
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_WanManager.InterfaceAvailableStatus"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_WanManager.InterfaceActiveStatus"
+          }
+        ],
+        "RBUS_METHOD": {
+          "Method": "Device.X_RDK_Xmidt.SendData",
+          "Parameters": [
+            {
+              "name": "msg_type",
+              "value": "event"
+            },
+            {
+              "name": "source",
+              "value": "telemetry2"
+            },
+            {
+              "name": "dest",
+              "value": "event:/profile-report/LTE-report"
+            },
+            {
+              "name": "content_type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "JSONEncoding": {
+          "ReportFormat": "NameValuePair",
+          "ReportTimestamp": "None"
+        }
+      }
+    },
+    {
+      "name": "TC_OPERATOR_WRONG",
+      "hash": "Hash_Default",
+      "value": {
+        "Description": "Trigger Condition operator invalid case",
+        "Version": ".01",
+        "Protocol": "RBUS_METHOD",
+        "EncodingType": "JSON",
+        "GenerateNow": false,
+        "ReportingInterval": 10,
+        "ActivationTimeOut": 360,
+        "TimeReference": "0001-01-01T00:00:00Z",
+        "Parameter": [],
+        "TriggerCondition": [
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_WanManager.InterfaceAvailableStatus",
+            "operator": "less"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_WanManager.InterfaceActiveStatus"
+          }
+        ],
+        "RBUS_METHOD": {
+          "Method": "Device.X_RDK_Xmidt.SendData",
+          "Parameters": [
+            {
+              "name": "msg_type",
+              "value": "event"
+            },
+            {
+              "name": "source",
+              "value": "telemetry2"
+            },
+            {
+              "name": "dest",
+              "value": "event:/profile-report/LTE-report"
+            },
+            {
+              "name": "content_type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "JSONEncoding": {
+          "ReportFormat": "NameValuePair",
+          "ReportTimestamp": "None"
+        }
+      }
+    },
+    {
+      "name": "TC_OPERATOR_THRESHOLD",
+      "hash": "Hash_Default",
+      "value": {
+        "Description": "Trigger Condition threshold is NULL",
+        "Version": ".01",
+        "Protocol": "RBUS_METHOD",
+        "EncodingType": "JSON",
+        "GenerateNow": false,
+        "ActivationTimeOut": 360,
+        "TimeReference": "0001-01-01T00:00:00Z",
+        "Parameter": [],
+        "TriggerCondition": [
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_WanManager.InterfaceAvailableStatus",
+            "operator": "any"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_WanManager.InterfaceActiveStatus",
+            "operator": "gt"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_GatewayManagement.Gateway.1.ActiveStatus"
+          }
+        ],
+        "RBUS_METHOD": {
+          "Method": "Device.X_RDK_Xmidt.SendData",
+          "Parameters": [
+            {
+              "name": "msg_type",
+              "value": "event"
+            },
+            {
+              "name": "source",
+              "value": "telemetry2"
+            },
+            {
+              "name": "dest",
+              "value": "event:/profile-report/LTE-report"
+            },
+            {
+              "name": "content_type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "JSONEncoding": {
+          "ReportFormat": "NameValuePair",
+          "ReportTimestamp": "None"
+        }
+      }
+    },
+    {
+      "name": "TC_REFERENCE_WRONG",
+      "hash": "Hash_Default",
+      "value": {
+        "Description": "Trigger Condition threshold is NULL",
+        "Version": ".01",
+        "Protocol": "RBUS_METHOD",
+        "EncodingType": "JSON",
+        "GenerateNow": false,
+        "ActivationTimeOut": 360,
+        "TimeReference": "0001-01-01T00:00:00Z",
+        "Parameter": [],
+        "TriggerCondition": [
+          {
+            "type": "dataModel",
+            "reference": "",
+            "operator": "any"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_WanManager.InterfaceActiveStatus",
+            "operator": "gt"
+          },
+          {
+            "type": "dataModel",
+            "reference": "Device.X_RDK_GatewayManagement.Gateway.1.ActiveStatus"
+          }
+        ],
+        "RBUS_METHOD": {
+          "Method": "Device.X_RDK_Xmidt.SendData",
+            "Parameters": [
+            {
+              "name": "msg_type",
+              "value": "event"
+            },
+            {
+              "name": "source",
+              "value": "telemetry2"
+            },
+            {
+              "name": "dest",
+              "value": "event:/profile-report/LTE-report"
+            },
+            {
+              "name": "content_type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "JSONEncoding": {
+          "ReportFormat": "NameValuePair",
+          "ReportTimestamp": "None"
+        }
+      }
+    }
+  ]
+}'''
+
+data_with_triggerconditon_pos = '''{
+    "profiles": [
+     {
+      "name": "TC_pos",
+      "hash": "Hash_default",
+      "value": {
+        "Description": "Trigger condition working case",
+        "Version": ".01",
+        "Protocol": "RBUS_METHOD",
+        "EncodingType": "JSON",
+        "GenerateNow": false,
+        "TimeReference": "0001-01-01T00:00:00Z",
+        "ActivationTimeout": 120,
+        "Parameter": [],
+        "TriggerCondition": [
+          {
+            "type": "dataModel",
+            "reference": "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RDKRemoteDebugger.Enable",
+            "operator": "any"
+          }
+        ],
+        "RBUS_METHOD": {
+         "Method": "Device.X_RDK_Xmidt.SendData",
+          "Parameters": [
+            {
+              "name": "msg_type",
+              "value": "event"
+            },
+            {
+              "name": "source",
+              "value": "telemetry2"
+            },
+            {
+              "name": "dest",
+              "value": "event:/profile-report/LTE-report"
+            },
+            {
+              "name": "content_type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "JSONEncoding": {
+          "ReportFormat": "NameValuePair",
+          "ReportTimestamp": "None"
+        }
+        }
+        }
+    ]
+}'''

--- a/test/functional-tests/tests/test_multiprofile_msgpacket.py
+++ b/test/functional-tests/tests/test_multiprofile_msgpacket.py
@@ -58,11 +58,11 @@ def test_without_namefield():
     remove_T2bootup_flag()
     clear_persistant_files()
     run_telemetry()
-    #run_shell_command("rdklogctrl telemetry2_0 LOG.RDK.T2 ~DEBUG")
-    sleep(10)
+    #Enabling debug log lines to get the HASH_ERROR_MSG in the logs
+    sleep(2)
 
     rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_without_namefield))
-    sleep(20)
+    sleep(10) 
 
     #Verify that profile is running
     ERROR_MSG = "Incomplete profile object information, unable to create profile"
@@ -71,25 +71,27 @@ def test_without_namefield():
     assert ERROR_MSG in grep_T2logs(ERROR_MSG) #Without name field
     assert LOG_MSG not in grep_T2logs(LOG_MSG) #Empty string in namefield 
     assert HASH_ERROR_MSG in grep_T2logs(HASH_ERROR_MSG) #without hash field
-    sleep(10)
+
 
 #negative case without hashvalue, without version field & without Protocol field
 @pytest.mark.run(order=2)
 def test_without_hashvalue():
     clear_T2logs()
-    #Adding this to avoid faiure
-    kill_telemetry(9)
-    remove_T2bootup_flag()
-    clear_persistant_files()
-    run_telemetry()
-    sleep(10)
+    #kill_telemetry(9) //Removing the Telemetry restart code as this test case doesn't require restart
+    RUN_START_TIME = dt.now()
+    #remove_T2bootup_flag()
+    #clear_persistant_files()
+    #run_telemetry()
     run_shell_command("rdklogctrl telemetry2_0 LOG.RDK.T2 ~DEBUG")
+    sleep(2)
     rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_without_hashvalue))
-    sleep(20)
+    sleep(20) #All profiles are erorr case profiles so adding 20 sec for processing of profiles
+    PROTOCOL_ERROR_MSG = "Incomplete Profile information, ignoring profile"
     assert "TR_AC12" not in grep_T2logs(LOG_PROFILE_ENABLE)  # without hash value
     assert "TR_AC14" in grep_T2logs(LOG_PROFILE_ENABLE)  # without version field
     assert "TR_AC15" not in grep_T2logs(LOG_PROFILE_ENABLE)  # without Protocol field
-    sleep(10)
+    assert PROTOCOL_ERROR_MSG in grep_T2logs(PROTOCOL_ERROR_MSG) # verify whether the protocol is given
+
 
 #negative cases:
 # random value for Protocol 
@@ -98,20 +100,25 @@ def test_without_hashvalue():
 @pytest.mark.run(order=3)
 def test_with_wrong_protocol_value():
     clear_T2logs()
-    #Adding this to avoid faiure
-    kill_telemetry(9)
-    remove_T2bootup_flag()
-    clear_persistant_files()
-    run_telemetry()
-    sleep(10)
+    RUN_START_TIME = dt.now()
+    #Adding this to avoid failure //Removing the Telemetry restart code as this test case doesn't require restart
+    #kill_telemetry(9)
+    #remove_T2bootup_flag()
+    #clear_persistant_files()
+    #run_telemetry()
+    #sleep(10)
+    run_shell_command("rdklogctrl telemetry2_0 LOG.RDK.T2 ~DEBUG")
+    sleep(2)
     rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_with_wrong_protocol_value))
-    sleep(20)
+    sleep(10)
     ERROR_WRONG_PROTOCOL = "Unsupported report sending protocol"
     assert ERROR_WRONG_PROTOCOL in grep_T2logs(ERROR_WRONG_PROTOCOL) #Verify the right protocol is given
     assert "TR_AC16" not in grep_T2logs(LOG_PROFILE_ENABLE) # Verify profile is not enabled with an incorrect protocol
     assert "TR_AC17" in grep_T2logs(LOG_PROFILE_ENABLE) # Verify Profile can be enabled for empty version
     assert "TR_AC13" not in grep_T2logs(LOG_PROFILE_ENABLE) # Verify Profile cannot be enabled for empty protocol
-    sleep(5)
+    sleep(5) 
+
+
 
 #negative cases
 # without EncodingType & ActivationTimeout values
@@ -119,9 +126,11 @@ def test_with_wrong_protocol_value():
 # without ActivationTimeout param
 # without ReportingInterval param
 # without GenerateNow param
+
 @pytest.mark.run(order=4)
 def test_without_EncodingType_ActivationTimeout_values():
     ERROR_REPORTING_INTERVAL = "If TriggerCondition is not given ReportingInterval parameter is mandatory"
+    ERROR_ENCODING = "Incomplete Profile information, ignoring profile"
     clear_T2logs()
     kill_telemetry(9)
     RUN_START_TIME = dt.now()
@@ -129,35 +138,37 @@ def test_without_EncodingType_ActivationTimeout_values():
     clear_persistant_files()
     run_telemetry()
     run_shell_command("rdklogctrl telemetry2_0 LOG.RDK.T2 ~DEBUG")
-    sleep(10)
+    sleep(2)
     rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_without_EncodingType_ActivationTimeout_values))
-    sleep(20)
-    sleep(5)
+    sleep(25)
     assert "TR_AC18" in grep_T2logs(LOG_PROFILE_ENABLE) # Verify profile is enabled with an empty encodingType
     assert "TR_AC19" in grep_T2logs(LOG_PROFILE_ENABLE) # Verify profile is enabled with an empty ActivationTimeout
     assert "TR_AC20" not in grep_T2logs(LOG_PROFILE_ENABLE) # Verify profile is not enabled without encodingType param
+    assert ERROR_ENCODING in grep_T2logs(ERROR_ENCODING)
     assert "TR_AC21" in grep_T2logs(LOG_PROFILE_ENABLE) # Verify profile is enabled without ActivationTimeout param
     assert ERROR_REPORTING_INTERVAL in grep_T2logs(ERROR_REPORTING_INTERVAL) # Verify ReportingInterval error is thrown
     assert "TR_AC22" not in grep_T2logs(LOG_PROFILE_ENABLE) # Verify profile is not enabled without ReportingInterval param
     assert "TR_AC23" in grep_T2logs(LOG_PROFILE_ENABLE) # Verify profile is enabled without GenerateNow param
-    sleep(5)
-    clear_T2logs()
+    sleep(5) #waiting for 5 sec before the next profile 
+
 
 #1).positive case for working of Reporting Interval
 #2).positive case for event marker & with count
 #3).positive case for event marker with accumulate
 @pytest.mark.run(order=5)
 def test_reporting_interval_working():
-    clear_T2logs()
-    kill_telemetry(9)
+    #clear_T2logs() //Removing the Telemetry restart code as this test case doesn't require restart
+    #kill_telemetry(9)
     RUN_START_TIME = dt.now()
-    remove_T2bootup_flag()
-    clear_persistant_files()
-    run_telemetry()
+    #remove_T2bootup_flag()
+    #clear_persistant_files()
+    #run_telemetry()
     run_shell_command("rdklogctrl telemetry2_0 LOG.RDK.T2 ~DEBUG")
-    sleep(10)
+    sleep(2)
+    rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_empty_profile))
+    sleep(2)
     rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_with_reporting_interval))
-    sleep(20)
+    sleep(10)
     REPORTING_INTERVAL_LOG1 = grep_T2logs("reporting interval is taken - TR_AC732")
 
     command1 = ["telemetry2_0_client TEST_EVENT_MARKER_1 300"]
@@ -165,27 +176,24 @@ def test_reporting_interval_working():
     command3 = ["telemetry2_0_client TEST_EVENT_MARKER_2 occurrance2"]
 
     run_shell_command(command1)
-    sleep(5)
     run_shell_command(command1)
-    sleep(5)
     run_shell_command(command2)
-    sleep(5)
     run_shell_command(command3)
-    sleep(5)
-    assert "45 sec" in REPORTING_INTERVAL_LOG1
-    sleep(50)
+    assert "20 sec" in REPORTING_INTERVAL_LOG1
+    sleep(20)
     assert "TIMEOUT for profile" in grep_T2logs("TR_AC732") #Verify reporting interval 
     assert "TEST_EVENT_MARKER_1\":\"2" in grep_T2logs("cJSON Report ") #verify event marker for count 
     assert "occurrance1" in grep_T2logs("TEST_EVENT_MARKER_2") #verify event marker for accummulate - 1
     assert "occurrance2" in grep_T2logs("TEST_EVENT_MARKER_2") #verify event marker for accummulate - 2
-    sleep(10)
+    sleep(2) #wait for 2 sec to verify whether this valid profile is running and generating report
 
-'''
+
 # verification for GenerateNow
 # count - grep marker validation
 # absolute - grep marker validation
 # Trim - grep marker validation
 # Datamodel validation
+
 @pytest.mark.run(order=6)
 def test_for_Generate_Now():
     clear_T2logs()
@@ -203,20 +211,17 @@ def test_for_Generate_Now():
     		"file writing to file.txt 23 lines\n"
 	    	)
     file.close()
+    sleep(2)
 
-    sleep(10)
     LOG_GENERATE_NOW = "Waiting for 0 sec for next TIMEOUT for profile"
     rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_with_Generate_Now))
-    sleep(20)
-    assert "TR_AC777" in grep_T2logs(LOG_GENERATE_NOW)  # verification for GenerateNow
     sleep(10)
+    assert "TR_AC777" in grep_T2logs(LOG_GENERATE_NOW)  # verification for GenerateNow
     assert "SYS_INFO_CrashPortalUpload_success\":\"2" in grep_T2logs("cJSON Report ") #  count - grep marker validation
     assert "FILE_Upload_Progress\":\" newfile1 20%" in grep_T2logs("cJSON Report ") #  absolute - grep marker validation
     assert "FILE_Read_Progress\":\"newfile2 line 10" in grep_T2logs("cJSON Report ") #  Trim - grep marker validation
     assert "MODEL_NAME" in grep_T2logs("cJSON Report ") #  Datamodel validation
-    sleep(10)
-    clear_T2logs()
-'''
+
 
 # Negative case with activation timeout less than reporting interval
 # Postive case for Empty report sent when reportEmpty is true
@@ -226,15 +231,14 @@ def test_for_Generate_Now():
 def test_for_invalid_activation_timeout():
     ERROR_PROFILE_TIMEOUT = "activationTimeoutPeriod is less than reporting interval. invalid profile: "
     rbus_set_data("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.ConfigURL", "string", "https://mockxconf:50050/loguploader1/getT2DCMSettings")
-    clear_T2logs()
+    #clear_T2logs()
     kill_telemetry(9)
     RUN_START_TIME = dt.now()
     remove_T2bootup_flag()
     clear_persistant_files()
     run_telemetry()
+    sleep(5)
     run_shell_command("rdklogctrl telemetry2_0 LOG.RDK.T2 ~DEBUG")
-    sleep(10)
-
     rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_with_less_activation_timeout))
     sleep(60)
     assert "TR_AC88" in grep_T2logs(ERROR_PROFILE_TIMEOUT) # Verify profile not set if activation timeout is less than reporting interval
@@ -244,7 +248,7 @@ def test_for_invalid_activation_timeout():
     assert "NEW TEST PROFILE" in grep_T2logs(LOG_PROFILE_SET) # Verify DCM profile is set
     assert "60 sec" in grep_T2logs("reporting interval is taken - NEW TEST PROFILE") #Verify DCM profile is running
     assert "AccountId\":\"Platform_Container_Test_DEVICE" in grep_T2logs("cJSON Report ") #verify report generated for DCM profile
-    sleep(10)
+    #sleep(10)
 
 #1).positive case for activation timeout
 #2).regex - grep marker validation
@@ -254,19 +258,19 @@ def test_for_invalid_activation_timeout():
 @pytest.mark.run(order=8)
 def test_with_delete_on_timeout():
     clear_T2logs()
-    kill_telemetry(9)
+    #kill_telemetry(9) //Removing the Telemetry restart code as this test case doesn't require restart
     RUN_START_TIME = dt.now()
-    remove_T2bootup_flag()
-    clear_persistant_files()
-    run_telemetry()
+    #remove_T2bootup_flag()
+    #clear_persistant_files()
+    #run_telemetry()
     run_shell_command("rdklogctrl telemetry2_0 LOG.RDK.T2 ~DEBUG")
-    sleep(10)
+    sleep(2)
     os.makedirs('/opt/logs', exist_ok=True)
     # Create log file with the logs needed for grep marker
     file = open('/opt/logs/core_log.txt', 'w')
     file.write("Success uploading report 200\n")
     file.close()
-    sleep(5)
+    sleep(2)
     LOG_PROFILE_TIMEOUT = "Profile activation timeout"
     LOG_DELETE_PROFILE = "removing profile :"
     rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_with_delete_on_timeout))
@@ -280,4 +284,75 @@ def test_with_delete_on_timeout():
     assert "TEST_EVENT_MARKER_2\":\"17" in grep_T2logs("cJSON Report ") #  regex - Event marker validation 
     assert "TR_AC66" in grep_T2logs(LOG_DELETE_PROFILE) #verify profile is removed from active profile list if DeleteOnTimeout is true
 
+
+#1.First reporting interval is applicable only when time ref is default - non-working case
+#2.Maxlatency is applicable only when time ref is not default - non- working case
+#3.Maxlatency is greater than reporting interval - non-working case 
+#4.Parameter array is entirely empty - non-working case
+@pytest.mark.run(order=9)
+def test_for_first_reporting_interval_Maxlatency():
+    MLU_ERROR_LOG = "MaxUploadLatency is greater than reporting interval. Invalid Profile"
+    TIMEOUT_LOG = "TIMEOUT for profile"
+    PARAM_ERROR_LOG = "Incomplete profile information, unable to create profile"
+    #clear_T2logs() //Removing the Telemetry restart code as this test case doesn't require restart
+    #kill_telemetry(9)
+    RUN_START_TIME = dt.now()
+    #remove_T2bootup_flag()
+    #clear_persistant_files()
+    #run_telemetry()
+    run_shell_command("rdklogctrl telemetry2_0 LOG.RDK.T2 ~DEBUG")
+    sleep(2)
+    rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_empty_profile)) # instead of telemetry restart giving empty profile to clear previous profile data 
+    sleep(2)
+    rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_with_first_reporting_interval_max_latency))
     sleep(5)
+    assert "PARAM_NULL" not in grep_T2logs(LOG_PROFILE_ENABLE)
+    assert "NA_FRI" in grep_T2logs(LOG_PROFILE_ENABLE) #verify when timeref is not default first reporting inetrval is not accepted
+    
+    assert "NA_MLU" in grep_T2logs(LOG_PROFILE_ENABLE)
+    assert "NA_FRI" not in grep_T2logs("Waiting for 5 sec for next TIMEOUT for profile as firstreporting interval is given")
+    sleep(10)
+    assert "NA_FRI" in grep_T2logs(TIMEOUT_LOG)
+    assert "NA_MLU" in grep_T2logs(TIMEOUT_LOG) #verify when timeref is not default max uploadlatency is accepted
+    assert MLU_ERROR_LOG in grep_T2logs(MLU_ERROR_LOG)
+
+@pytest.mark.run(order=10)
+def test_for_triggerCondition_negative_case():
+    TC_ERROR_LOG = "TriggerCondition is invalid, unable to create profile"
+    RUN_START_TIME = dt.now()
+    run_shell_command("rdklogctrl telemetry2_0 LOG.RDK.T2 DEBUG")
+    sleep(2)
+    rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_empty_profile))
+    sleep(2)
+    rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_with_triggerconditon_neg))
+    sleep(5)
+    assert TC_ERROR_LOG in grep_T2logs(TC_ERROR_LOG)
+    assert "Null type verifyMsgPckTriggerCondition ++out" in grep_T2logs("Null type verifyMsgPckTriggerCondition ++out")
+    assert "Null reference verifyMsgPckTriggerCondition ++out" in grep_T2logs("Null reference verifyMsgPckTriggerCondition ++out")
+    assert "Unexpected type verifyMsgPckTriggerCondition ++out" in grep_T2logs("Unexpected type verifyMsgPckTriggerCondition ++out")
+    assert "Null operator verifyMsgPckTriggerCondition ++out" in grep_T2logs("Null operator verifyMsgPckTriggerCondition ++out")
+    assert "Unexpected operator verifyMsgPckTriggerCondition ++out" in grep_T2logs("Unexpected operator verifyMsgPckTriggerCondition ++out")
+    assert "Null threshold verifyMsgPckTriggerCondition ++out" in grep_T2logs("Null threshold verifyMsgPckTriggerCondition ++out")
+    assert "Unexpected reference verifyMsgPckTriggerCondition ++out" in grep_T2logs("Unexpected reference verifyMsgPckTriggerCondition ++out")
+
+@pytest.mark.run(order=11)
+def test_for_triggerCondition_working_case():
+    clear_T2logs()
+    RUN_START_TIME = dt.now()
+    kill_telemetry(9)
+    remove_T2bootup_flag()
+    clear_persistant_files()
+    run_telemetry()
+    sleep(5)
+    run_shell_command("rdklogctrl telemetry2_0 LOG.RDK.T2 ~DEBUG")
+    sleep(2)
+    rbus_set_data(T2_REPORT_PROFILE_PARAM_MSG_PCK, "string", tomsgpack(data_with_triggerconditon_pos))
+    sleep(5)
+    subprocess.run("rbuscli set Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RDKRemoteDebugger.Enable  bool false", shell=True)
+    sleep(2)
+    assert "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RDKRemoteDebugger.Enable" in grep_T2logs("TriggerConditionResult")
+    assert "false" in grep_T2logs("TriggerConditionResult")
+    subprocess.run("rbuscli set Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RDKRemoteDebugger.Enable  bool true", shell=True)
+    sleep(2)
+    assert "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RDKRemoteDebugger.Enable" in grep_T2logs("TriggerConditionResult")
+    assert "true" in grep_T2logs("TriggerConditionResult") 

--- a/test/functional-tests/tests/test_xconf_communications.py
+++ b/test/functional-tests/tests/test_xconf_communications.py
@@ -80,7 +80,7 @@ def test_xconf_404():
     ERROR_MSG1 = "Telemetry XCONF communication Failed with http code"
     ERROR_MSG2 = "XConf Telemetry profile not set for this device, uninitProfileList."
 
-    sleep(20)
+    sleep(10)
     response1 = grep_T2logs(ERROR_MSG1)
     assert ERROR_MSG1 in response1
     sleep(10)
@@ -95,7 +95,7 @@ def test_change_profile():
     rbus_set_data("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.ConfigURL", "string", "https://mockxconf:50050/loguploader1/getT2DCMSettings")
     #exec_reload the telemetry profile
     kill_telemetry(12)
-    sleep(20)
+    sleep(10)
     assert os.path.exists(XCONF_PERSISTANT_FILE)
     assert "NEW TEST PROFILE" in grep_T2logs("NEW TEST PROFILE")
     
@@ -113,10 +113,30 @@ def test_verify_report():
     assert ERROR_MSG2 in grep_T2logs(ERROR_MSG2)
 
 @pytest.mark.run(order=8)
+def test_log_upload():
+    LOG_MSG1 = "CollectAndReportXconf ++in profileName : NEW TEST PROFILE"
+    LOG_MSG2 = "cJSON Report ="
+    clear_T2logs()
+    kill_telemetry(10)
+    sleep(10)
+    assert LOG_MSG1 in grep_T2logs(LOG_MSG1)
+    assert LOG_MSG2 in grep_T2logs(LOG_MSG2)
+
+@pytest.mark.run(order=9)
+def test_log_upload_on_demand():
+    LOG_MSG1 = "CollectAndReportXconf ++in profileName : NEW TEST PROFILE"
+    LOG_MSG2 = "cJSON Report ="
+    clear_T2logs()
+    kill_telemetry(29)
+    sleep(10)
+    assert LOG_MSG1 in grep_T2logs(LOG_MSG1)
+    assert LOG_MSG2 in grep_T2logs(LOG_MSG2)
+
+@pytest.mark.run(order=10)
 def test_verify_persistant_file():
     assert os.path.exists(XCONF_PERSISTANT_FILE)
 
-@pytest.mark.run(order=9)
+@pytest.mark.run(order=11)
 def test_xconf_retry_for_connection_errors():
     clear_T2logs()
     rbus_set_data("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.ConfigURL", "string", "https://mockxconf:80/loguploader1/getT2DCMSettings")


### PR DESCRIPTION
Reason for change: Added the L2 test cases for telemetry
Test Procedure: Execute sh test/run_l2.sh
Risks: Medium
Priority: P1