### PR TITLE
 RDK-55195: Adding RCVRY cert for rdkcertselector

### DIFF
--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -259,12 +259,14 @@ static void checkStateRed(char *cert_buf, size_t buf_size)
 {
     if (access("/tmp/stateRedEnabled", F_OK) == 0) 
     {
-         T2Info("%s, T2:Cert selector: Device is in state red\n", __func__);
+         T2Info("%s, T2:Cert selector: Device is in state red\n",
+             __func__);
          snprintf(cert_buf, buf_size, "RCVRY");
     } 
     else 
     {
-         T2Info("%s, T2:Cert selector: Device is not in state red\n", __func__);
+         T2Info("%s, T2:Cert selector: Device is not in state red\n",
+             __func__);
          snprintf(cert_buf, buf_size, "MTLS");
     }
     if (curlCertSelector != NULL) 
@@ -291,14 +293,16 @@ static void curlCertSelectorInit()
     
     if(curlCertSelector == NULL)
     {
-        curlCertSelector = rdkcertselector_new( NULL, NULL, cert_group );
+        curlCertSelector = rdkcertselector_new(NULL, NULL, cert_group);
         if(curlCertSelector == NULL)
         {
-            T2Error("%s, T2:Cert selector initialization failed %s\n", __func__, cert_group);
+          T2Error("%s, T2:Cert selector initialization failed %s\n",
+                   __func__, cert_group);
         }
         else
         {
-            T2Info("%s, T2:Cert selector initialization successfully %s\n", __func__, cert_group);
+          T2Info("%s, T2:Cert selector initialization successfully %s\n",
+                  __func__, cert_group);
         }
     }
 }


### PR DESCRIPTION
Reason for change: rdkcertselector init for RCVRY certficate
Test Procedure: None
Risks: Low