### PR TITLE
RDK-55195: Adding RCVRY cert for rdkcertselector

### DIFF
--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -255,10 +255,6 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
     return T2ERROR_SUCCESS;
 }
 #ifdef LIBRDKCERTSEL_BUILD
-static void checkStateRed(const char *certBuf, int bufSize)
-{
-    T2Info("%s, T2:Device is not in state red\n", __func__);
-}
 void curlCertSelectorFree()
 {
     rdkcertselector_free(&curlCertSelector);
@@ -272,7 +268,10 @@ void curlCertSelectorFree()
     }
 }
 static void curlCertSelectorInit()
-{    
+{
+    char cert_group[8] = {0};
+    checkStateRed(cert_group, sizeof(cert_group));
+
     if(curlCertSelector == NULL)
     {
         curlCertSelector = rdkcertselector_new( NULL, NULL, "MTLS" );

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -255,22 +255,7 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
     return T2ERROR_SUCCESS;
 }
 #ifdef LIBRDKCERTSEL_BUILD
-static void checkStateRed(char *cert_buf, size_t buf_size)
-{
-    if (access("/tmp/stateRedEnabled", F_OK) == 0) 
-    {
-        T2Info("%s, T2:Cert selector: Device is in state red\n", __func__);
-        snprintf(cert_buf, buf_size, "%s", "RCVRY");
-    } 
-    else 
-    {
-        T2Info("%s, T2:Cert selector: Device is not in state red\n", __func__);
-        snprintf(cert_buf, buf_size, "%s", "MTLS");
-    }
-    if (curlCertSelector != NULL) {
-         curlCertSelectorFree();
-    }
-}
+// CertSelector Init
 void curlCertSelectorFree()
 {
     rdkcertselector_free(&curlCertSelector);
@@ -285,12 +270,9 @@ void curlCertSelectorFree()
 }
 static void curlCertSelectorInit()
 {
-    char cert_group[8] = {0};
-    checkStateRed(cert_group, sizeof(cert_group));
-    
     if(curlCertSelector == NULL)
     {
-        curlCertSelector = rdkcertselector_new( NULL, NULL, cert_group );
+        curlCertSelector = rdkcertselector_new( NULL, NULL, "MTLS" );
         if(curlCertSelector == NULL)
         {
             T2Error("%s, T2:Cert selector initialization failed\n", __func__);

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -255,7 +255,7 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
     return T2ERROR_SUCCESS;
 }
 #ifdef LIBRDKCERTSEL_BUILD
-void checkStateRed(char *cert_buf, size_t buf_size)
+static void checkStateRed(char *cert_buf, size_t buf_size)
 {
     if(access("/tmp/stateRedEnabled", F_OK) == 0)
     {

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -257,7 +257,7 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
 #ifdef LIBRDKCERTSEL_BUILD
 static void checkStateRed(char *certBuf, size_t bufSize)
 {
-    T2Info("%s, T2:Cert selector: Device is not in state red\n", __func__);
+    T2Info("%s, T2:Device is not in state red\n", __func__);
 }
 void curlCertSelectorFree()
 {
@@ -273,8 +273,8 @@ void curlCertSelectorFree()
 }
 static void curlCertSelectorInit()
 {
-    char certGroup[8] = {0};
-    checkStateRed(certGroup, sizeof(certGroup));
+    //char certGroup[8] = {0};
+    //checkStateRed(certGroup, sizeof(certGroup));
     
     if(curlCertSelector == NULL)
     {

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -255,7 +255,7 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
     return T2ERROR_SUCCESS;
 }
 #ifdef LIBRDKCERTSEL_BUILD
-static void checkStateRed(char *certBuf, size_t bufSize)
+static void checkStateRed(const char *certBuf, int bufSize)
 {
     T2Info("%s, T2:Device is not in state red\n", __func__);
 }
@@ -272,10 +272,7 @@ void curlCertSelectorFree()
     }
 }
 static void curlCertSelectorInit()
-{
-    //char certGroup[8] = {0};
-    //checkStateRed(certGroup, sizeof(certGroup));
-    
+{    
     if(curlCertSelector == NULL)
     {
         curlCertSelector = rdkcertselector_new( NULL, NULL, "MTLS" );

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -259,7 +259,7 @@ void checkStateRed(char *cert_buf, size_t buf_size)
 {
     if (access("/tmp/stateRedEnabled", F_OK) == 0) 
     {
-        T2Info("%s, T2:Cert selector: Device is in state red\n", __func__);
+         T2Debug("%s Device is not in red state\n", __FUNCTION__);
     }
 }
 void curlCertSelectorFree()

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -257,6 +257,19 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
 #ifdef LIBRDKCERTSEL_BUILD
 void checkStateRed(char *cert_buf, size_t buf_size)
 {
+    if (access("/tmp/stateRedEnabled", F_OK) == 0) 
+    {
+        T2Info("%s, T2:Cert selector: Device is in state red\n", __func__);
+        snprintf(cert_buf, buf_size, "%s", "RCVRY");
+    } 
+    else 
+    {
+        T2Info("%s, T2:Cert selector: Device is not in state red\n", __func__);
+        snprintf(cert_buf, buf_size, "%s", "MTLS");
+    }
+    if (curlCertSelector != NULL) {
+         curlCertSelectorFree();
+    }
 }
 void curlCertSelectorFree()
 {

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -260,13 +260,13 @@ void checkStateRed(char *cert_buf, size_t buf_size)
     if(access("/tmp/stateRedEnabled", F_OK) == 0)
     {
         T2Debug("%s Device is in red state\n", __FUNCTION__);
-        snprintf(cert_buf, buf_size, "%s", "RCVRY");
+        snprintf(cert_buf, buf_size, "RCVRY");
         curlCertSelectorFree();
     }
     else
     {
         T2Debug("%s Device is not in red state\n", __FUNCTION__);
-        snprintf(cert_buf, buf_size, "%s", "MTLS");
+        snprintf(cert_buf, buf_size, "MTLS");
         curlCertSelectorFree();
     }
 }

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -259,8 +259,13 @@ void checkStateRed(char *cert_buf, size_t buf_size)
 {
     if(access("/tmp/stateRedEnabled", F_OK) == 0)
     {
-        T2Debug("%s Device is not in red state\n", __FUNCTION__);
+        T2Debug("%s Device is in red state\n", __FUNCTION__);
         snprintf(cert_buf, buf_size, "%s", "RCVRY");
+    }
+    else
+    {
+        T2Debug("%s Device is not in red state\n", __FUNCTION__);
+        snprintf(cert_buf, buf_size, "%s", "MTLS");
     }
 }
 void curlCertSelectorFree()

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -255,7 +255,22 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
     return T2ERROR_SUCCESS;
 }
 #ifdef LIBRDKCERTSEL_BUILD
-// CertSelector Init
+static void checkStateRed(char *cert_buf, size_t buf_size)
+{
+    if (access("/tmp/stateRedEnabled", F_OK) == 0) 
+    {
+        T2Info("%s, T2:Cert selector: Device is in state red\n", __func__);
+        snprintf(cert_buf, buf_size, "%s", "RCVRY");
+    } 
+    else 
+    {
+        T2Info("%s, T2:Cert selector: Device is not in state red\n", __func__);
+        snprintf(cert_buf, buf_size, "%s", "MTLS");
+    }
+    if (curlCertSelector != NULL) {
+         curlCertSelectorFree();
+    }
+}
 void curlCertSelectorFree()
 {
     rdkcertselector_free(&curlCertSelector);

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -255,21 +255,9 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
     return T2ERROR_SUCCESS;
 }
 #ifdef LIBRDKCERTSEL_BUILD
-static void checkStateRed(char *cert_buf, size_t buf_size)
+static void checkStateRed(char *certBuf, size_t bufSize)
 {
-    if (access("/tmp/stateRedEnabled", F_OK) == 0) 
-    {
-        T2Info("%s, T2:Cert selector: Device is in state red\n", __func__);
-        snprintf(cert_buf, buf_size, "%s", "RCVRY");
-    } 
-    else 
-    {
-        T2Info("%s, T2:Cert selector: Device is not in state red\n", __func__);
-        snprintf(cert_buf, buf_size, "%s", "MTLS");
-    }
-    if (curlCertSelector != NULL) {
-         curlCertSelectorFree();
-    }
+    T2Info("%s, T2:Cert selector: Device is not in state red\n", __func__);
 }
 void curlCertSelectorFree()
 {
@@ -285,6 +273,9 @@ void curlCertSelectorFree()
 }
 static void curlCertSelectorInit()
 {
+    char certGroup[8] = {0};
+    checkStateRed(certGroup, sizeof(certGroup));
+    
     if(curlCertSelector == NULL)
     {
         curlCertSelector = rdkcertselector_new( NULL, NULL, "MTLS" );

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -255,6 +255,9 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
     return T2ERROR_SUCCESS;
 }
 #ifdef LIBRDKCERTSEL_BUILD
+void checkStateRed(char *cert_buf, size_t buf_size)
+{
+}
 void curlCertSelectorFree()
 {
     rdkcertselector_free(&curlCertSelector);

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -267,7 +267,7 @@ void checkStateRed(char *cert_buf, size_t buf_size)
         T2Debug("%s Device is not in red state\n", __FUNCTION__);
         snprintf(cert_buf, buf_size, "%s", "MTLS");
     }
-    if(curlCertSelector != NULL) 
+    if(NULL != curlCertSelector) 
     {
          curlCertSelectorFree();
     }

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -267,9 +267,9 @@ void checkStateRed(char *cert_buf, size_t buf_size)
         T2Debug("%s Device is not in red state\n", __FUNCTION__);
         snprintf(cert_buf, buf_size, "%s", "MTLS");
     }
-    if(NULL != curlCertSelector) 
+    if(curlCertSelector) 
     {
-         curlCertSelectorFree();
+        curlCertSelectorFree();
     }
 }
 void curlCertSelectorFree()

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -261,13 +261,11 @@ static void checkStateRed(char *cert_buf, size_t buf_size)
     {
         T2Info("%s, Device is in red state\n", __func__);
         snprintf(cert_buf, buf_size, "RCVRY");
-        //curlCertSelectorFree();
     }
     else
     {
         T2Info("%s, Device is not in red state\n", __func__);
         snprintf(cert_buf, buf_size, "MTLS");
-        //curlCertSelectorFree();
     }
     if(curlCertSelector)
     {

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -259,16 +259,18 @@ static void checkStateRed(char *cert_buf, size_t buf_size)
 {
     if(access("/tmp/stateRedEnabled", F_OK) == 0)
     {
-        //T2Debug("%s Device is in red state\n", __FUNCTION__);
         T2Info("%s, Device is in red state\n", __func__);
         snprintf(cert_buf, buf_size, "RCVRY");
-        curlCertSelectorFree();
+        //curlCertSelectorFree();
     }
     else
     {
-        //T2Debug("%s Device is not in red state\n", __FUNCTION__);
         T2Info("%s, Device is not in red state\n", __func__);
         snprintf(cert_buf, buf_size, "MTLS");
+        //curlCertSelectorFree();
+    }
+    if(curlCertSelector)
+    {
         curlCertSelectorFree();
     }
 }

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -257,8 +257,11 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
 #ifdef LIBRDKCERTSEL_BUILD
 void checkStateRed(char *cert_buf, size_t buf_size)
 {
-    T2Debug("%s Device is not in red state\n", __FUNCTION__);
-    snprintf(cert_buf, buf_size, "%s", "RCVRY");
+    if(access("/tmp/stateRedEnabled", F_OK) == 0)
+    {
+        T2Debug("%s Device is not in red state\n", __FUNCTION__);
+        snprintf(cert_buf, buf_size, "%s", "RCVRY");
+    }
 }
 void curlCertSelectorFree()
 {

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -260,15 +260,6 @@ void checkStateRed(char *cert_buf, size_t buf_size)
     if (access("/tmp/stateRedEnabled", F_OK) == 0) 
     {
         T2Info("%s, T2:Cert selector: Device is in state red\n", __func__);
-        snprintf(cert_buf, buf_size, "%s", "RCVRY");
-    } 
-    else 
-    {
-        T2Info("%s, T2:Cert selector: Device is not in state red\n", __func__);
-        snprintf(cert_buf, buf_size, "%s", "MTLS");
-    }
-    if (curlCertSelector != NULL) {
-         curlCertSelectorFree();
     }
 }
 void curlCertSelectorFree()

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -293,11 +293,11 @@ static void curlCertSelectorInit()
         curlCertSelector = rdkcertselector_new( NULL, NULL, cert_group );
         if(curlCertSelector == NULL)
         {
-            T2Error("%s, T2:Cert selector %s initialization failed\n", __func__, cert_group);
+            T2Error("%s, T2:Cert selector initialization failed\n", __func__);
         }
         else
         {
-            T2Info("%s, T2:Cert selector %s initialization successfully\n", __func__, cert_group);
+            T2Info("%s, T2:Cert selector initialization successfully\n", __func__);
         }
     }
 }

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -257,20 +257,17 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
 #ifdef LIBRDKCERTSEL_BUILD
 void checkStateRed(char *cert_buf, size_t buf_size)
 {
-    if(curlCertSelector != NULL)
-    {
-        curlCertSelectorFree();
-    }
-    
     if(access("/tmp/stateRedEnabled", F_OK) == 0)
     {
         T2Debug("%s Device is in red state\n", __FUNCTION__);
         snprintf(cert_buf, buf_size, "%s", "RCVRY");
+        curlCertSelectorFree();
     }
     else
     {
         T2Debug("%s Device is not in red state\n", __FUNCTION__);
         snprintf(cert_buf, buf_size, "%s", "MTLS");
+        curlCertSelectorFree();
     }
 }
 void curlCertSelectorFree()

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -255,6 +255,22 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
     return T2ERROR_SUCCESS;
 }
 #ifdef LIBRDKCERTSEL_BUILD
+static void checkStateRed(char *cert_buf, size_t buf_size)
+{
+    if (access("/tmp/stateRedEnabled", F_OK) == 0) 
+    {
+        T2Info("%s, T2:Cert selector: Device is in state red\n", __func__);
+        snprintf(cert_buf, buf_size, "%s", "RCVRY");
+    } 
+    else 
+    {
+        T2Info("%s, T2:Cert selector: Device is not in state red\n", __func__);
+        snprintf(cert_buf, buf_size, "%s", "MTLS");
+    }
+    if (curlCertSelector != NULL) {
+         curlCertSelectorFree();
+    }
+}
 void curlCertSelectorFree()
 {
     rdkcertselector_free(&curlCertSelector);
@@ -269,16 +285,19 @@ void curlCertSelectorFree()
 }
 static void curlCertSelectorInit()
 {
+    char cert_group[8] = {0};
+    checkStateRed(cert_group, sizeof(cert_group));
+    
     if(curlCertSelector == NULL)
     {
-        curlCertSelector = rdkcertselector_new( NULL, NULL, "MTLS" );
+        curlCertSelector = rdkcertselector_new( NULL, NULL, cert_group );
         if(curlCertSelector == NULL)
         {
-            T2Error("%s, T2:Cert selector initialization failed\n", __func__);
+            T2Error("%s, T2:Cert selector %s initialization failed\n", __func__, cert_group);
         }
         else
         {
-            T2Info("%s, T2:Cert selector initialization successfully\n", __func__);
+            T2Info("%s, T2:Cert selector %s initialization successfully\n", __func__, cert_group);
         }
     }
 }

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -257,6 +257,11 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
 #ifdef LIBRDKCERTSEL_BUILD
 void checkStateRed(char *cert_buf, size_t buf_size)
 {
+    if(curlCertSelector != NULL)
+    {
+        curlCertSelectorFree();
+    }
+    
     if(access("/tmp/stateRedEnabled", F_OK) == 0)
     {
         T2Debug("%s Device is in red state\n", __FUNCTION__);
@@ -266,10 +271,6 @@ void checkStateRed(char *cert_buf, size_t buf_size)
     {
         T2Debug("%s Device is not in red state\n", __FUNCTION__);
         snprintf(cert_buf, buf_size, "%s", "MTLS");
-    }
-    if(curlCertSelector) 
-    {
-        curlCertSelectorFree();
     }
 }
 void curlCertSelectorFree()

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -257,10 +257,7 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
 #ifdef LIBRDKCERTSEL_BUILD
 void checkStateRed(char *cert_buf, size_t buf_size)
 {
-    if (access("/tmp/stateRedEnabled", F_OK) == 0) 
-    {
-         T2Debug("%s Device is not in red state\n", __FUNCTION__);
-    }
+    T2Debug("%s Device is not in red state\n", __FUNCTION__);
 }
 void curlCertSelectorFree()
 {

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -259,13 +259,15 @@ static void checkStateRed(char *cert_buf, size_t buf_size)
 {
     if(access("/tmp/stateRedEnabled", F_OK) == 0)
     {
-        T2Debug("%s Device is in red state\n", __FUNCTION__);
+        //T2Debug("%s Device is in red state\n", __FUNCTION__);
+        T2Info("%s, Device is in red state\n", __func__);
         snprintf(cert_buf, buf_size, "RCVRY");
         curlCertSelectorFree();
     }
     else
     {
-        T2Debug("%s Device is not in red state\n", __FUNCTION__);
+        //T2Debug("%s Device is not in red state\n", __FUNCTION__);
+        T2Info("%s, Device is not in red state\n", __func__);
         snprintf(cert_buf, buf_size, "MTLS");
         curlCertSelectorFree();
     }
@@ -289,7 +291,7 @@ static void curlCertSelectorInit()
 
     if(curlCertSelector == NULL)
     {
-        curlCertSelector = rdkcertselector_new( NULL, NULL, "MTLS" );
+        curlCertSelector = rdkcertselector_new( NULL, NULL, cert_group );
         if(curlCertSelector == NULL)
         {
             T2Error("%s, T2:Cert selector initialization failed\n", __func__);

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -267,6 +267,10 @@ void checkStateRed(char *cert_buf, size_t buf_size)
         T2Debug("%s Device is not in red state\n", __FUNCTION__);
         snprintf(cert_buf, buf_size, "%s", "MTLS");
     }
+    if(curlCertSelector != NULL) 
+    {
+         curlCertSelectorFree();
+    }
 }
 void curlCertSelectorFree()
 {

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -258,6 +258,7 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
 void checkStateRed(char *cert_buf, size_t buf_size)
 {
     T2Debug("%s Device is not in red state\n", __FUNCTION__);
+    snprintf(cert_buf, buf_size, "%s", "RCVRY");
 }
 void curlCertSelectorFree()
 {


### PR DESCRIPTION
Reason for change: rdkcertselector init for RCVRY certficate
Test Procedure: None
Risks: Low