### PR TITLE
RDK-55195: Adding RCVRY cert for rdkcertselector

### DIFF
--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -255,6 +255,23 @@ static T2ERROR setPayload(CURL *curl, const char* payload, childResponse *childC
     return T2ERROR_SUCCESS;
 }
 #ifdef LIBRDKCERTSEL_BUILD
+static void checkStateRed(char *cert_buf, size_t buf_size)
+{
+    if(access("/tmp/stateRedEnabled", F_OK) == 0)
+    {
+        T2Info("%s, Device is in state red\n", __func__);
+        snprintf(cert_buf, buf_size, "RCVRY");
+    }
+    else
+    {
+        T2Info("%s, Device is not in state red\n", __func__);
+        snprintf(cert_buf, buf_size, "MTLS");
+    }
+    if(curlCertSelector)
+    {
+        curlCertSelectorFree();
+    }
+}
 void curlCertSelectorFree()
 {
     rdkcertselector_free(&curlCertSelector);
@@ -269,9 +286,12 @@ void curlCertSelectorFree()
 }
 static void curlCertSelectorInit()
 {
+    char cert_group[8] = {0};
+    checkStateRed(cert_group, sizeof(cert_group));
+    
     if(curlCertSelector == NULL)
     {
-        curlCertSelector = rdkcertselector_new( NULL, NULL, "MTLS" );
+        curlCertSelector = rdkcertselector_new( NULL, NULL, cert_group );
         if(curlCertSelector == NULL)
         {
             T2Error("%s, T2:Cert selector initialization failed\n", __func__);

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -267,10 +267,6 @@ static void checkStateRed(char *cert_buf, size_t buf_size)
         snprintf(cert_buf, buf_size, "MTLS");
         T2Info("%s, Device is not in red state\n", __func__);
     }
-    if(curlCertSelector)
-    {
-        curlCertSelectorFree();
-    }
 }
 void curlCertSelectorFree()
 {

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -259,12 +259,12 @@ static void checkStateRed(char *cert_buf, size_t buf_size)
 {
     if(access("/tmp/stateRedEnabled", F_OK) == 0)
     {
-        T2Info("%s, Device is in state red\n", __func__);
+        T2Info("%s, Device is in red state\n", __func__);
         snprintf(cert_buf, buf_size, "RCVRY");
     }
     else
     {
-        T2Info("%s, Device is not in state red\n", __func__);
+        T2Info("%s, Device is not in red state\n", __func__);
         snprintf(cert_buf, buf_size, "MTLS");
     }
     if(curlCertSelector)

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -259,13 +259,13 @@ static void checkStateRed(char *cert_buf, size_t buf_size)
 {
     if(access("/tmp/stateRedEnabled", F_OK) == 0)
     {
-        T2Info("%s, Device is in red state\n", __func__);
         snprintf(cert_buf, buf_size, "RCVRY");
+        T2Info("%s, Device is in red state\n", __func__);
     }
     else
     {
-        T2Info("%s, Device is not in red state\n", __func__);
         snprintf(cert_buf, buf_size, "MTLS");
+        T2Info("%s, Device is not in red state\n", __func__);
     }
     if(curlCertSelector)
     {


### PR DESCRIPTION
Reason for change: rdkcertselector init for RCVRY certficate
Test Procedure: None
Risks: Low