### PR TITLE
To enable MTLS support for T2  in pods 

### DIFF
--- a/source/bulkdata/reportprofiles.c
+++ b/source/bulkdata/reportprofiles.c
@@ -1461,7 +1461,7 @@ bool isMtlsEnabled(void)
     isT2MtlsEnable = true;
     return true;
 #else
-#if !defined (ENABLE_RDKC_SUPPORT)
+#if !defined(ENABLE_RDKC_SUPPORT) && !defined(DEVICE_EXTENDER)
     char *paramValue = NULL;
 
     if(initT2MtlsEnable == false)

--- a/source/utils/t2MtlsUtils.c
+++ b/source/utils/t2MtlsUtils.c
@@ -34,15 +34,19 @@
 #include "rdkconfig.h"
 #endif
 
-
-#if !defined(ENABLE_RDKC_SUPPORT)
-static const char* staticMtlsCert = "/etc/ssl/certs/staticXpkiCrt.pk12";
+static bool UsedynamicMtlsCert2 = false;
 #ifdef LIBRDKCONFIG_BUILD
 static const char* staticMtlsDestFile = "/tmp/.cfgStaticxpki";
 static const char* dynamicMtlsDestFile = "/tmp/.cfgDynamicxpki";
 #endif
+#if defined(DEVICE_EXTENDER)
+static const char* staticMtlsCert = "/usr/opensync/certs/cert.p12";
+static const char* dynamicMtlsCert = "/mnt/data/pstore/certs/devicecert_1.pk12";
 
-static bool UsedynamicMtlsCert2 = false;
+#else
+#if !defined(ENABLE_RDKC_SUPPORT)
+static const char* staticMtlsCert = "/etc/ssl/certs/staticXpkiCrt.pk12";
+
 #if defined(ENABLE_RDKB_SUPPORT)
 static const char* dynamicMtlsCert = "/nvram/certs/devicecert_1.pk12";
 #else
@@ -54,6 +58,7 @@ static char* staticMtlsCert = "";
 static char* staticPassPhrase = "";
 static char* dynamicMtlsCert = "";
 static char* dynamicPassPhrase = "";
+#endif
 #endif
 
 void initMtls()

--- a/source/utils/t2MtlsUtils.c
+++ b/source/utils/t2MtlsUtils.c
@@ -34,21 +34,22 @@
 #include "rdkconfig.h"
 #endif
 
-static bool UsedynamicMtlsCert2 = false;
+
+#if !defined(ENABLE_RDKC_SUPPORT)
+#if defined(DEVICE_EXTENDER)
+static const char* staticMtlsCert = "/usr/opensync/certs/cert.p12";
+#else
+static const char* staticMtlsCert = "/etc/ssl/certs/staticXpkiCrt.pk12";
+#endif
 #ifdef LIBRDKCONFIG_BUILD
 static const char* staticMtlsDestFile = "/tmp/.cfgStaticxpki";
 static const char* dynamicMtlsDestFile = "/tmp/.cfgDynamicxpki";
 #endif
-#if defined(DEVICE_EXTENDER)
-static const char* staticMtlsCert = "/usr/opensync/certs/cert.p12";
-static const char* dynamicMtlsCert = "/mnt/data/pstore/certs/devicecert_1.pk12";
-
-#else
-#if !defined(ENABLE_RDKC_SUPPORT)
-static const char* staticMtlsCert = "/etc/ssl/certs/staticXpkiCrt.pk12";
-
+static bool UsedynamicMtlsCert2 = false;
 #if defined(ENABLE_RDKB_SUPPORT)
 static const char* dynamicMtlsCert = "/nvram/certs/devicecert_1.pk12";
+#elif defined(DEVICE_EXTENDER)
+static const char* dynamicMtlsCert = "/mnt/data/pstore/certs/devicecert_1.pk12";
 #else
 static const char* dynamicMtlsCert = "/opt/certs/devicecert_1.pk12";
 #endif
@@ -58,7 +59,6 @@ static char* staticMtlsCert = "";
 static char* staticPassPhrase = "";
 static char* dynamicMtlsCert = "";
 static char* dynamicPassPhrase = "";
-#endif
 #endif
 
 void initMtls()


### PR DESCRIPTION
To enable MTLS support for T2  in pods 