### PR TITLE
DELIA-67022:T2 crash with signature strcmp during reboot test

### DIFF
--- a/source/bulkdata/profilexconf.c
+++ b/source/bulkdata/profilexconf.c
@@ -638,7 +638,8 @@ bool ProfileXConf_isNameEqual(char* profileName)
     pthread_mutex_lock(&plMutex);
     if(initialized)
     {
-        if(singleProfile && !strcmp(singleProfile->name, profileName))
+        T2Info("singleProfile->name = %s and profileName = %s\n", singleProfile->name, profileName);
+        if(singleProfile && (singleProfile->name != NULL) && (profileName != NULL) && !strcmp(singleProfile->name, profileName)) //Adding NULL check to avoid strcmp crash
         {
             isName = true;
         }


### PR DESCRIPTION
Reason for change: To avoid the strcmp crash during reboot test Test Procedure: There should not be crash and regression issues during reboot testing
Risks: Low
Priority: P1