### PR TITLE
RDK-58398:Fix curl dependency for some API's

### DIFF
--- a/source/xconf-client/xconfclient.c
+++ b/source/xconf-client/xconfclient.c
@@ -1175,7 +1175,7 @@ T2ERROR fetchRemoteConfiguration(char *configURL, char **configData)
         rc = curl_url_set(requestURL, CURLUPART_URL, configURL, 0);
         if(rc != CURLUE_OK)
         {
-            T2Error("T2: Curl unable to set config url %s\n", curl_url_strerror(rc));
+            T2Error("T2: Curl unable to set config url %s\n", configURL);
             T2_CURL_ERRROR(rc);
             curl_url_cleanup(requestURL);
             return ret;


### PR DESCRIPTION
Reason for change: curl_url_strerror() is available from 7.80.0 added logic to check the version for using certain curl API's
ref : https://curl.se/changes.html#7_80_0[curl_url_strerror()](https://curl.se/bug/?i=7605)
Test Procedure: Verify that the URL is using
Risks: Low