### PR TITLE
 RDKB-60894 : crash with strnstr and memcmp_eq in T2

### DIFF
--- a/source/bulkdata/profilexconf.c
+++ b/source/bulkdata/profilexconf.c
@@ -306,6 +306,9 @@ static void* CollectAndReportXconf(void* data)
             {
                 encodeEventMarkersInJSON(valArray, profile->eMarkerList);
             }
+            profile->grepSeekProfile->execCounter += 1;
+            T2Info("Execution Count = %d\n", profile->grepSeekProfile->execCounter);
+
             ret = prepareJSONReport(profile->jsonReportObj, &jsonReport);
             destroyJSONReport(profile->jsonReportObj);
             profile->jsonReportObj = NULL;

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -115,7 +115,6 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
     // Main search loop optimized for longer patterns
     for (size_t i = 0; i < search_len;)
     {
-	T2Info("for loop \n");
         if (haystack[i] == '\0')
         {
             break;

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -860,8 +860,7 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
                 close(tmp_rd);
                 return NULL;
             }
-            addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, 0);
-            addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, offset_in_page_size_multiple);
+            
            // bytes_ignored_rotated = bytes_ignored;
            T2Debug("seek_value is %ld rotated fsize is %ld main fsize is %ld\n", seek_value, rb.st_size, sb.st_size);
             if(rb.st_size > seek_value)
@@ -869,6 +868,8 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
                 rotated_fsize = (off_t) (rb.st_size - seek_value);
                 main_fsize = sb.st_size;
 		        bytes_ignored_rotated = bytes_ignored;
+                addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, 0);
+                addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, offset_in_page_size_multiple);
                 T2Debug("bytes ignored rotated is %u bytes_ignored_main %u\n", bytes_ignored_rotated, bytes_ignored_main);
             }
             else
@@ -876,6 +877,8 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
                 rotated_fsize = rb.st_size;
                 main_fsize = (off_t) (sb.st_size - seek_value);
 		        bytes_ignored_main = bytes_ignored;
+                addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, offset_in_page_size_multiple);
+                addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, 0);
                 T2Debug("bytes ignored rotated is %u bytes_ignored_main %u\n", bytes_ignored_rotated, bytes_ignored_main);
             }
 
@@ -897,6 +900,7 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
             }
             else
             {
+                
                 T2Debug("Log file got rotated. Ignoring invalid mapping\n");
                 close(tmp_fd);
                 close(fd);

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -863,7 +863,7 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
             addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, 0);
             addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, offset_in_page_size_multiple);
            // bytes_ignored_rotated = bytes_ignored;
-           T2Debug("seek_value is %ld rotated fsize is %ld main fsize is %ld and sent is %ld\n", seek_value, rb.st_size, sb.st_size,sent );
+           T2Debug("seek_value is %ld rotated fsize is %ld main fsize is %ld\n", seek_value, rb.st_size, sb.st_size);
             if(rb.st_size > seek_value)
             {
                 rotated_fsize = (off_t) (rb.st_size - seek_value);

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -836,10 +836,22 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
             T2Info("mmap done\n");
             addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, offset_in_page_size_multiple);
             bytes_ignored_rotated = bytes_ignored;
-            rotated_fsize = rb.st_size - seek_value;
-	    T2Info("rotated fsize is %jd\n", (intmax_t)rotated_fsize);
+            T2Info("seekvalue = %jd\n", (intmax_t)seek_value);
+            T2Info("rb.st_size = %jd\n", (intmax_t)rb.st_size);
+            if(rb.st_size > seek_value)
+            {
+                rotated_fsize = rb.st_size - seek_value;
+                main_fsize = sb.st_size;
+            }
+            else
+            {
+                rotated_fsize = rb.st_size;
+                main_fsize = sb.st_size - seek_value;
+            }
+
+            T2Info("rotated fsize is %jd\n", (intmax_t)rotated_fsize);
             main_fsize = sb.st_size;
-	    T2Info("main fsize is %jd\n", (intmax_t)main_fsize);
+            T2Info("main fsize is %jd\n", (intmax_t)main_fsize);
             close(rd);
             close(tmp_rd);
             rd = -1;
@@ -1057,8 +1069,8 @@ static int parseMarkerListOptimized(GrepSeekProfile *gsProfile, Vector * ip_vMar
     }  // Loop of marker list ends here
 
 
-    gsProfile->execCounter += 1;
-    T2Debug("Execution Count = %d\n", gsProfile->execCounter);
+    // gsProfile->execCounter += 1;
+    // T2Debug("Execution Count = %d\n", gsProfile->execCounter);
 
     if (prevfile != NULL)
     {

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -836,21 +836,22 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
             addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, 0);
             addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, offset_in_page_size_multiple);
             bytes_ignored_rotated = bytes_ignored;
-	    T2Debug("rotated fsize is %jd\n", (intmax_t)rb.st_size);
-            T2Debug("main fsize is %jd\n", (intmax_t)sb.st_size);
+            T2Debug("seek_value is %ld\n", seek_value);
+	        T2Debug("rotated fsize is %ld\n", rb.st_size);
+            T2Debug("main fsize is %ld\n", sb.st_size);
             if(rb.st_size > seek_value)
             {
-                rotated_fsize = rb.st_size - seek_value;
+                rotated_fsize = (off_t) (rb.st_size - seek_value);
                 main_fsize = sb.st_size;
             }
             else
             {
                 rotated_fsize = rb.st_size;
-                main_fsize = sb.st_size - seek_value;
+                main_fsize = (off_t) (sb.st_size - seek_value);
             }
 
-            T2Debug("rotated fsize is %jd\n", (intmax_t)rotated_fsize);
-            T2Debug("main fsize is %jd\n", (intmax_t)main_fsize);
+            T2Debug("rotated fsize is %ld\n", rotated_fsize);
+            T2Debug("main fsize is %ld\n", main_fsize);
             close(rd);
             close(tmp_rd);
             rd = -1;
@@ -864,7 +865,10 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
                 addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, offset_in_page_size_multiple);
                 T2Info("mmap done\n");
                 bytes_ignored_main = bytes_ignored;
-                main_fsize = sb.st_size - seek_value;
+                T2Debug("fsize is %ld\n", sb.st_size);
+                T2Debug("seek_value is %ld\n", seek_value);
+                main_fsize = (off_t) (sb.st_size - seek_value);
+                T2Debug("main fsize is %ld\n", main_fsize);
             }
             else
             {
@@ -883,7 +887,10 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
             addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, offset_in_page_size_multiple);
             T2Info("mmap done\n");
             bytes_ignored_main = bytes_ignored;
-            main_fsize = sb.st_size - seek_value;
+            main_fsize = (off_t) (sb.st_size - seek_value);
+            T2Debug("seek_value is %ld\n", seek_value);
+            T2Debug("fsize is %ld\n", sb.st_size);
+            T2Debug("main fsize is %ld\n", main_fsize);
         }
         else
         {

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -116,7 +116,6 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
     // Main search loop optimized for longer patterns
     for (size_t i = 0; i < search_len;)
     {
-	printf("haystack i = %c\n", haystack[i]);
         if (haystack[i] == '\0')
         {
             break;
@@ -142,7 +141,6 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
         else
         {
             i += skip;
-	    T2Info("i value is %zu\t", i);
             // But don't skip past a potential match
             while (i < search_len && haystack[i] != first_char)
             {

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -111,10 +111,12 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
 
     // Skip value for Boyer-Moore-like optimization
     size_t skip = (needle_len >= 4) ? needle_len / 4 : 1;
-
+    T2Info("skip = %zu\n", skip);
+    T2Info("before for loop needle_len %zu len %zu search len %zu \n", needle_len, len, search_len);
     // Main search loop optimized for longer patterns
     for (size_t i = 0; i < search_len;)
     {
+	printf("haystack i = %c\n", haystack[i]);
         if (haystack[i] == '\0')
         {
             break;
@@ -140,6 +142,7 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
         else
         {
             i += skip;
+	    T2Info("i value is %zu\t", i);
             // But don't skip past a potential match
             while (i < search_len && haystack[i] != first_char)
             {
@@ -836,7 +839,9 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
             addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, offset_in_page_size_multiple);
             bytes_ignored_rotated = bytes_ignored;
             rotated_fsize = rb.st_size - seek_value;
+	    T2Info("rotated fsize is %zu\n", rotated_fsize);
             main_fsize = sb.st_size;
+	    T2Info("main fsize is %zu\n", main_fsize);
             close(rd);
             close(tmp_rd);
             rd = -1;

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -120,7 +120,6 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
         {
             break;
         }
-        T2Info("before if loop \n");
         // Quick boundary check using multiple characters
         if (haystack[i] == first_char &&
                 haystack[i + 1] == second_char &&

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -82,7 +82,7 @@ typedef struct
  */
 static const char *strnstr(const char *haystack, const char *needle, size_t len)
 {
-    T2Info("Inside strnstr\n");
+    T2Debug("Inside strnstr\n");
     if (!haystack || !needle)
     {
         return NULL;
@@ -146,6 +146,7 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
             {
                 i++;
             }
+	    T2Debug("else strnstr\n");
         }
     }
     T2Debug("strnstr end without match\n");
@@ -411,7 +412,7 @@ static inline void formatCount(char* buffer, size_t size, int count)
 
 static int getCountPatternMatch(FileDescriptor* fileDescriptor, const char* pattern)
 {
-    T2Info("Inside getCountPatternMatch\n");
+    T2Debug("Inside getCountPatternMatch\n");
     if (!fileDescriptor || !fileDescriptor->cfaddr || !pattern || !*pattern || fileDescriptor->cf_file_size <= 0)
     {
         T2Error("Invalid file descriptor arguments pattern match\n");
@@ -835,6 +836,8 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
             addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, 0);
             addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, offset_in_page_size_multiple);
             bytes_ignored_rotated = bytes_ignored;
+	    T2Debug("rotated fsize is %jd\n", (intmax_t)rb.st_size);
+            T2Debug("main fsize is %jd\n", (intmax_t)sb.st_size);
             if(rb.st_size > seek_value)
             {
                 rotated_fsize = rb.st_size - seek_value;

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -111,8 +111,8 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
 
     // Skip value for Boyer-Moore-like optimization
     size_t skip = (needle_len >= 4) ? needle_len / 4 : 1;
-    T2Info("skip = %zu\n", skip);
-    T2Info("before for loop needle_len %zu len %zu search len %zu \n", needle_len, len, search_len);
+    T2Debug("skip = %zu\n", skip);
+    T2Debug("before for loop needle_len %zu len %zu search len %zu \n", needle_len, len, search_len);
     // Main search loop optimized for longer patterns
     for (size_t i = 0; i < search_len;)
     {
@@ -132,10 +132,10 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
             // Only if all boundary chars match, do a full comparison
             if (memcmp(haystack + i + 2, needle + 2, needle_len - 4) == 0)
             {
-                T2Info("strnstr end with match\n");
+                T2Debug("strnstr end with match\n");
                 return haystack + i;
             }
-            T2Info("strnstr next iteration\n");
+            T2Debug("strnstr next iteration\n");
             i++; // Move one by one after a partial match
         }
         else
@@ -148,7 +148,7 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
             }
         }
     }
-    T2Info("strnstr end without match\n");
+    T2Debug("strnstr end without match\n");
     return NULL;
 }
 
@@ -833,11 +833,8 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
                 return NULL;
             }
             addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, 0);
-            T2Info("mmap done\n");
             addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, offset_in_page_size_multiple);
             bytes_ignored_rotated = bytes_ignored;
-            T2Info("seekvalue = %jd\n", (intmax_t)seek_value);
-            T2Info("rb.st_size = %jd\n", (intmax_t)rb.st_size);
             if(rb.st_size > seek_value)
             {
                 rotated_fsize = rb.st_size - seek_value;
@@ -849,9 +846,8 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
                 main_fsize = sb.st_size - seek_value;
             }
 
-            T2Info("rotated fsize is %jd\n", (intmax_t)rotated_fsize);
-            main_fsize = sb.st_size;
-            T2Info("main fsize is %jd\n", (intmax_t)main_fsize);
+            T2Debug("rotated fsize is %jd\n", (intmax_t)rotated_fsize);
+            T2Debug("main fsize is %jd\n", (intmax_t)main_fsize);
             close(rd);
             close(tmp_rd);
             rd = -1;

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -909,7 +909,7 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
         {
             addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, offset_in_page_size_multiple);
             bytes_ignored_main = bytes_ignored;
-            main_fsize = (off_t) (sb.st_size - seek_value);
+            main_fsize = sb.st_size - seek_value;
             T2Debug("main fsize is %ld\n", main_fsize);
         }
         else

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -126,13 +126,15 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
                 haystack[i + needle_len - 1] == last_char &&
                 haystack[i + needle_len - 2] == prelast_char)
         {
+            T2Info("starting memcmp needle_len %zu len %zu search len %zu \n", needle_len, len, search_len);
 
             // Only if all boundary chars match, do a full comparison
             if (memcmp(haystack + i + 2, needle + 2, needle_len - 4) == 0)
             {
-		T2Info("strnstr end with match\n");
+                T2Info("strnstr end with match\n");
                 return haystack + i;
             }
+            T2Info("strnstr next iteration\n");
             i++; // Move one by one after a partial match
         }
         else

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -839,9 +839,9 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
             addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, offset_in_page_size_multiple);
             bytes_ignored_rotated = bytes_ignored;
             rotated_fsize = rb.st_size - seek_value;
-	    T2Info("rotated fsize is %zu\n", rotated_fsize);
+	    T2Info("rotated fsize is %jd\n", (intmax_t)rotated_fsize);
             main_fsize = sb.st_size;
-	    T2Info("main fsize is %zu\n", main_fsize);
+	    T2Info("main fsize is %jd\n", (intmax_t)main_fsize);
             close(rd);
             close(tmp_rd);
             rd = -1;

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -130,6 +130,7 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
             // Only if all boundary chars match, do a full comparison
             if (memcmp(haystack + i + 2, needle + 2, needle_len - 4) == 0)
             {
+		T2Info("strnstr end with match\n");
                 return haystack + i;
             }
             i++; // Move one by one after a partial match
@@ -144,7 +145,7 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
             }
         }
     }
-
+    T2Info("strnstr end without match\n");
     return NULL;
 }
 
@@ -407,6 +408,7 @@ static inline void formatCount(char* buffer, size_t size, int count)
 
 static int getCountPatternMatch(FileDescriptor* fileDescriptor, const char* pattern)
 {
+    T2Info("Inside getCountPatternMatch\n");
     if (!fileDescriptor || !fileDescriptor->cfaddr || !pattern || !*pattern || fileDescriptor->cf_file_size <= 0)
     {
         T2Error("Invalid file descriptor arguments pattern match\n");
@@ -452,7 +454,6 @@ static int getCountPatternMatch(FileDescriptor* fileDescriptor, const char* patt
                 break;
             }
             count++;
-            T2Info("count is %d\n", count);
             size_t advance = (size_t)(found - cur) + patlen;
             cur = found + patlen;
             if (bytes_left < advance)
@@ -463,6 +464,7 @@ static int getCountPatternMatch(FileDescriptor* fileDescriptor, const char* patt
         }
 
     }
+    T2Info("count is %d\n", count);
     return count;
 }
 
@@ -546,7 +548,7 @@ static char* getAbsolutePatternMatch(FileDescriptor* fileDescriptor, const char*
     }
     memcpy(result, start, length);
     result[length] = '\0';
-    T2Debug("Found pattern '%s' in file, result: '%s'\n", pattern, result);
+    T2Info("Found pattern '%s' in file, result: '%s'\n", pattern, result);
     return result;
 }
 

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -120,7 +120,7 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
         {
             break;
         }
-
+        T2Info("before if loop \n");
         // Quick boundary check using multiple characters
         if (haystack[i] == first_char &&
                 haystack[i + 1] == second_char &&
@@ -142,11 +142,12 @@ static const char *strnstr(const char *haystack, const char *needle, size_t len)
         {
             i += skip;
             // But don't skip past a potential match
+	    T2Debug(" else strnstr i value is %zu haystack %c\n", i, haystack[i]);
             while (i < search_len && haystack[i] != first_char)
             {
                 i++;
             }
-	    T2Debug("else strnstr\n");
+	    T2Debug("haystack value is %c\n",haystack[i]);
         }
     }
     T2Debug("strnstr end without match\n");
@@ -836,9 +837,9 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
             addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, 0);
             addrrf = mmap(NULL, rb.st_size, PROT_READ, MAP_PRIVATE, tmp_rd, offset_in_page_size_multiple);
             bytes_ignored_rotated = bytes_ignored;
-            T2Debug("seek_value is %ld\n", seek_value);
-	        T2Debug("rotated fsize is %ld\n", rb.st_size);
-            T2Debug("main fsize is %ld\n", sb.st_size);
+           // T2Debug("seek_value is %ld\n", seek_value);
+	   // T2Debug("rotated fsize is %ld\n", rb.st_size);
+           // T2Debug("main fsize is %ld\n", sb.st_size);
             if(rb.st_size > seek_value)
             {
                 rotated_fsize = (off_t) (rb.st_size - seek_value);
@@ -863,10 +864,9 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
             if(seek_value < sb.st_size)
             {
                 addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, offset_in_page_size_multiple);
-                T2Info("mmap done\n");
                 bytes_ignored_main = bytes_ignored;
-                T2Debug("fsize is %ld\n", sb.st_size);
-                T2Debug("seek_value is %ld\n", seek_value);
+             //   T2Debug("fsize is %ld\n", sb.st_size);
+             //   T2Debug("seek_value is %ld\n", seek_value);
                 main_fsize = (off_t) (sb.st_size - seek_value);
                 T2Debug("main fsize is %ld\n", main_fsize);
             }
@@ -885,11 +885,10 @@ static FileDescriptor* getFileDeltaInMemMapAndSearch(const int fd, const off_t s
         if(seek_value < sb.st_size)
         {
             addrcf = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, tmp_fd, offset_in_page_size_multiple);
-            T2Info("mmap done\n");
             bytes_ignored_main = bytes_ignored;
             main_fsize = (off_t) (sb.st_size - seek_value);
-            T2Debug("seek_value is %ld\n", seek_value);
-            T2Debug("fsize is %ld\n", sb.st_size);
+          //  T2Debug("seek_value is %ld\n", seek_value);
+          //  T2Debug("fsize is %ld\n", sb.st_size);
             T2Debug("main fsize is %ld\n", main_fsize);
         }
         else

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -269,6 +269,7 @@ static void t2DaemonMainModeInit( )
 
     DAEMONPID = getpid(); // save the pid of the deamon
     T2Debug("Telemetry 2.0 Process PID %d\n", (int)DAEMONPID); //Debug line
+    LOGInit();
     sigaction(SIGTERM, &act, NULL);
     sigaction(SIGUSR1, &act, NULL);
     sigaction(LOG_UPLOAD, &act, NULL);
@@ -321,7 +322,7 @@ int main()
 {
     pid_t process_id = 0;
     pid_t sid = 0;
-    LOGInit();
+   // LOGInit();
 
     /* Abort if another instance of telemetry2_0 is already running */
     if (checkAnotherTelemetryInstance())

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -321,7 +321,7 @@ int main()
 {
     pid_t process_id = 0;
     pid_t sid = 0;
-    // LOGInit();
+    LOGInit();
 
     /* Abort if another instance of telemetry2_0 is already running */
     if (checkAnotherTelemetryInstance())
@@ -371,7 +371,6 @@ int main()
 
 
     T2Info("Initializing Telemetry 2.0 Component\n");
-    LOGInit();
     t2DaemonMainModeInit();
     return 0;
 }

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -269,6 +269,7 @@ static void t2DaemonMainModeInit( )
 
     DAEMONPID = getpid(); // save the pid of the deamon
     T2Debug("Telemetry 2.0 Process PID %d\n", (int)DAEMONPID); //Debug line
+
     sigaction(SIGTERM, &act, NULL);
     sigaction(SIGUSR1, &act, NULL);
     sigaction(LOG_UPLOAD, &act, NULL);

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -269,7 +269,6 @@ static void t2DaemonMainModeInit( )
 
     DAEMONPID = getpid(); // save the pid of the deamon
     T2Debug("Telemetry 2.0 Process PID %d\n", (int)DAEMONPID); //Debug line
-    LOGInit();
     sigaction(SIGTERM, &act, NULL);
     sigaction(SIGUSR1, &act, NULL);
     sigaction(LOG_UPLOAD, &act, NULL);
@@ -322,7 +321,7 @@ int main()
 {
     pid_t process_id = 0;
     pid_t sid = 0;
-   // LOGInit();
+    LOGInit();
 
     /* Abort if another instance of telemetry2_0 is already running */
     if (checkAnotherTelemetryInstance())

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -269,7 +269,6 @@ static void t2DaemonMainModeInit( )
 
     DAEMONPID = getpid(); // save the pid of the deamon
     T2Debug("Telemetry 2.0 Process PID %d\n", (int)DAEMONPID); //Debug line
-
     sigaction(SIGTERM, &act, NULL);
     sigaction(SIGUSR1, &act, NULL);
     sigaction(LOG_UPLOAD, &act, NULL);
@@ -322,7 +321,7 @@ int main()
 {
     pid_t process_id = 0;
     pid_t sid = 0;
-    LOGInit();
+    // LOGInit();
 
     /* Abort if another instance of telemetry2_0 is already running */
     if (checkAnotherTelemetryInstance())
@@ -372,6 +371,7 @@ int main()
 
 
     T2Info("Initializing Telemetry 2.0 Component\n");
+    LOGInit();
     t2DaemonMainModeInit();
     return 0;
 }


### PR DESCRIPTION
Reason for change: To resolve the crash during self lookup of data in check rotated scenario
Test Procedure: There should not be crash and regression issues. Wait for 15 minutes to report for check rotated case. Also check whether the markers are observed with proper data when other logfiles got rotated with marker string.
Risks: High
Priority: P0
