### PR TITLE
TELEMTERY-24  Add "REPORT_TYPE":"CACHED" to cache reports

### DIFF
--- a/source/bulkdata/profile.c
+++ b/source/bulkdata/profile.c
@@ -686,6 +686,8 @@ static void* CollectAndReport(void* data)
                             Vector_RemoveItem(profile->cachedReportList, (void*) thirdCachedReport, NULL);
                             free(thirdCachedReport);
                         }
+			// Before caching the report, add "REPORT_TYPE": "CACHED"
+                        tagReportAsCached(&jsonReport);
                         Vector_PushBack(profile->cachedReportList, jsonReport);
 
                         T2Info("Report Cached, No. of reportes cached = %lu\n", (unsigned long )Vector_Size(profile->cachedReportList));

--- a/source/bulkdata/profilexconf.c
+++ b/source/bulkdata/profilexconf.c
@@ -344,6 +344,8 @@ static void* CollectAndReportXconf(void* data)
                     Vector_RemoveItem(profile->cachedReportList, (void*) thirdCachedReport, NULL);
                     free(thirdCachedReport);
                 }
+		// Before caching the report, add "REPORT_TYPE": "CACHED"
+		// tagReportAsCached(&jsonReport);
                 Vector_PushBack(profile->cachedReportList, strdup(jsonReport));
                 profile->reportInProgress = false;
                 /* CID 187010: Dereference before null check */
@@ -414,6 +416,8 @@ static void* CollectAndReportXconf(void* data)
                         Vector_RemoveItem(profile->cachedReportList, (void*) thirdCachedReport, NULL);
                         free(thirdCachedReport);
                     }
+		    // Before caching the report, add "REPORT_TYPE": "CACHED"
+		    tagReportAsCached(&jsonReport);
                     Vector_PushBack(profile->cachedReportList, strdup(jsonReport));
 
                     T2Info("Report Cached, No. of reportes cached = %lu\n", (unsigned long)Vector_Size(profile->cachedReportList));

--- a/source/reportgen/reportgen.c
+++ b/source/reportgen/reportgen.c
@@ -876,3 +876,51 @@ char *prepareHttpUrl(T2HTTP *http)
 
     return httpUrl;
 }
+
+void tagReportAsCached(char **jsonReport)
+{
+    	if (!jsonReport) {
+		T2Error("jsonReport is NULL\n");
+		return;
+    	}
+
+  	cJSON *jsonReportObj = cJSON_Parse(*jsonReport);
+    	if (!jsonReportObj) {
+		T2Error("Failed to parse JSON report\n");
+		return;
+    	}
+
+    	cJSON *reportTypeEntry = cJSON_CreateObject();
+    	if (!reportTypeEntry) {
+		T2Error("Failed to create REPORT_TYPE object\n");
+		destroyJSONReport(jsonReportObj);
+		return;
+    	}
+    	cJSON_AddStringToObject(reportTypeEntry, "REPORT_TYPE", "CACHED");
+       	cJSON *searchResult = cJSON_GetObjectItemCaseSensitive(jsonReportObj, "searchResult");
+     	if (searchResult && cJSON_IsArray(searchResult)) {
+		T2Info("Inserting REPORT_TYPE: CACHED at index 1 of searchResult array\n");
+		cJSON_InsertItemInArray(searchResult, 1, reportTypeEntry);
+    	} else {
+		cJSON *reportArray = cJSON_GetObjectItemCaseSensitive(jsonReportObj, "Report");
+		if (reportArray && cJSON_IsArray(reportArray)) {
+	    		T2Info("Inserting REPORT_TYPE: CACHED at beginning of Report array\n");
+	    		cJSON_InsertItemInArray(reportArray, 0, reportTypeEntry);
+		} else {
+	    		T2Error("Neither 'searchResult' nor 'Report' arrays found in the JSON\n");
+	    		destroyJSONReport(reportTypeEntry);
+	    		destroyJSONReport(jsonReportObj);
+	    		return;
+		}
+    	}
+
+    	char *updatedJsonReport = cJSON_PrintUnformatted(jsonReportObj);
+    	if (updatedJsonReport) {
+		free(*jsonReport);  // Freeing the old report only after the new one is generated
+		*jsonReport = updatedJsonReport;
+    	}
+
+    	destroyJSONReport(jsonReportObj);
+}
+
+

--- a/source/reportgen/reportgen.h
+++ b/source/reportgen/reportgen.h
@@ -79,4 +79,6 @@ T2ERROR prepareJSONReport(cJSON* jsonObj, char** reportBuff);
 
 char *prepareHttpUrl(T2HTTP *http);
 
+void tagReportAsCached(char **jsonReport);
+
 #endif /* _REPORTGEN_H_ */


### PR DESCRIPTION
[Description]
To differentiate between normal and cached reports, set "REPORT_TYPE": "CACHED" for cached reports. This makes it clear in the report that it's a cached one. 

[Solution]
Modified the logic to include "REPORT_TYPE":"CACHED" in cached reports.

[Testing]
Verified that cached reports now include "REPORT_TYPE":"CACHED".