### PR TITLE
ISSUE-76: Ensure Signal Handler in not preempted

### DIFF
--- a/source/bulkdata/profilexconf.c
+++ b/source/bulkdata/profilexconf.c
@@ -498,7 +498,7 @@ reportXconfThreadEnd :
     reportThreadExits = false;
     pthread_mutex_unlock(&plMutex);
     pthread_cond_destroy(&reuseThread);
-    T2Debug("%s --out exiting the CollectAndReportXconf thread \n", __FUNCTION__);
+    T2Info("%s --out exiting the CollectAndReportXconf thread \n", __FUNCTION__);
     return NULL;
 }
 

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -267,6 +267,8 @@ static void t2DaemonMainModeInit( )
     sigaddset(&blocking_signal, LOG_UPLOAD_ONDEMAND);
     sigaddset(&blocking_signal, SIGIO);
 
+    act.sa_mask = blocking_signal; // block these signals while inside handler
+
     DAEMONPID = getpid(); // save the pid of the deamon
     T2Debug("Telemetry 2.0 Process PID %d\n", (int)DAEMONPID); //Debug line
 


### PR DESCRIPTION
Reason for Change: Prevent signal handlers from being preempted; serialize handling for signals 10 and 12 to avoid concurrent execution.
Test Procedure: Aggressively simulate report uploads and verify that no crashes occur.
Risks: Medium
Priority: P1