### PR TITLE
RDKB-61931 : Removing Openssl Engine setup/override logic in Telemetry

### DIFF
--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -188,15 +188,6 @@ static T2ERROR setMtlsHeaders(CURL *curl, const char* certFile, const char* pPas
         return T2ERROR_FAILURE;
     }
     CURLcode code = CURLE_OK;
-#ifndef LIBRDKCERTSEL_BUILD
-    code = curl_easy_setopt(curl, CURLOPT_SSLENGINE_DEFAULT, 1L);
-    if(code != CURLE_OK)
-    {
-        childCurlResponse->curlSetopCode = code;
-        childCurlResponse->lineNumber = __LINE__;
-        return T2ERROR_FAILURE;
-    }
-#endif
     code = curl_easy_setopt(curl, CURLOPT_SSLCERTTYPE, "P12");
     if(code != CURLE_OK)
     {
@@ -322,7 +313,6 @@ T2ERROR sendReportOverHTTP(char *httpUrl, char *payload, pid_t* outForkedPid)
     rdkcertselector_h thisCertSel = NULL;
     rdkcertselectorStatus_t curlGetCertStatus;
     char *pCertURI = NULL;
-    char *pEngine = NULL;
     bool state_red_enable = false;
 #endif
     char *pCertFile = NULL;
@@ -459,21 +449,6 @@ T2ERROR sendReportOverHTTP(char *httpUrl, char *payload, pid_t* outForkedPid)
                 goto child_cleanReturn;
             }
 #ifdef LIBRDKCERTSEL_BUILD
-            pEngine = rdkcertselector_getEngine(thisCertSel);
-            if(pEngine != NULL){
-                code = curl_easy_setopt(curl, CURLOPT_SSLENGINE, pEngine);
-                if(code != CURLE_OK){                    
-                    code = curl_easy_setopt(curl, CURLOPT_SSLENGINE_DEFAULT, 1L);
-                }
-            }else{
-                code = curl_easy_setopt(curl, CURLOPT_SSLENGINE_DEFAULT, 1L);
-            }
-            if(code != CURLE_OK)
-            {
-                childCurlResponse.curlSetopCode = code;
-                curl_easy_cleanup(curl);
-                goto child_cleanReturn;
-            }
             do
             {
                 pCertFile = NULL;

--- a/source/xconf-client/xconfclient.c
+++ b/source/xconf-client/xconfclient.c
@@ -593,7 +593,6 @@ T2ERROR doHttpGet(char* httpsUrl, char **data)
 #ifdef LIBRDKCERTSEL_BUILD
     rdkcertselectorStatus_t xcGetCertStatus;
     char *pCertURI = NULL;
-    char *pEngine = NULL;
 #endif
     char *pCertFile = NULL;
     char *pPasswd = NULL;
@@ -731,19 +730,6 @@ T2ERROR doHttpGet(char* httpsUrl, char **data)
             if(mtls_enable == true)
             {
 #ifdef LIBRDKCERTSEL_BUILD
-                pEngine = rdkcertselector_getEngine(xcCertSelector);
-                if(pEngine != NULL){
-                    code = curl_easy_setopt(curl, CURLOPT_SSLENGINE, pEngine);
-                    if(code != CURLE_OK){                    
-                        code = curl_easy_setopt(curl, CURLOPT_SSLENGINE_DEFAULT, 1L);
-                    }                    
-                } else {
-                    code = curl_easy_setopt(curl, CURLOPT_SSLENGINE_DEFAULT, 1L);
-                }
-                if(code != CURLE_OK)
-                {
-                    T2Error("%s : Curl set opts failed with error %s \n", __FUNCTION__, curl_easy_strerror(code));
-                }
                 do
                 {
                     pCertFile = NULL;


### PR DESCRIPTION
Reason for change: Open SSL lib will load automatically
Test Procedure: Build and verify
Risks: None
Priority: P1

Signed-off-by: Ankur Adroja <Ankur_Adroja@comcast.com>