### PR TITLE
RDKB-62477:Clients related split markers with value as 0 after Upgrad…

### DIFF
--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -616,9 +616,9 @@ static int getAbsolutePatternMatch(FileDescriptor* fileDescriptor, GrepMarker* m
     result[length] = '\0';
 
     //TODO Remove this logic to limit the markers with value as 0 after the dashboards are updated with the present framework RDKB-62477
-    if(strncmp(result, "0", 1) == 0)
+    if(strcmp(result, "0") == 0 )
     {
-        T2Debug("Dropping the marker %s as the value is 0\n", marker->markerName);
+        T2Warning("Dropping the marker %s as the value is 0\n", marker->markerName);
         marker->u.markerValue = NULL;
         free(result);
         result = NULL;

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -614,22 +614,20 @@ static int getAbsolutePatternMatch(FileDescriptor* fileDescriptor, GrepMarker* m
     }
     memcpy(result, start, length);
     result[length] = '\0';
-    //TODO Remove the logic to limit the markers with value as 0 RDKB-62477
-    splitSuffix = strstr(marker->markerName, SPLITMARKER_SUFFIX);
-    if(splitSuffix != NULL && strcmp(splitSuffix, SPLITMARKER_SUFFIX) == 0)
+
+    //TODO Remove this logic to limit the markers with value as 0 after the dashboards are updated with the present framework RDKB-62477
+    if(strncmp(result, "0", 1) == 0)
     {
-        if(strcmp(result, "0") == 0) {
-            marker->u.markerValue = NULL;
-            free(result);
-            result = NULL;
-        }
-        else{
-            marker->u.markerValue = result;
-        }
+        T2Debug("Dropping the marker %s as the value is 0\n", marker->markerName);
+        marker->u.markerValue = NULL;
+        free(result);
+        result = NULL;
     }
-    else{
+    else
+    {
         marker->u.markerValue = result;
     }
+
     T2Debug("%s --out\n", __FUNCTION__);
     return 0;
 }

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -618,7 +618,7 @@ static int getAbsolutePatternMatch(FileDescriptor* fileDescriptor, GrepMarker* m
     //TODO Remove this logic to limit the markers with value as 0 after the dashboards are updated with the present framework RDKB-62477
     if(strcmp(result, "0") == 0 )
     {
-        T2Warning("Dropping the marker %s as the value is 0\n", marker->markerName);
+        T2Debug("Dropping the marker %s as the value is 0\n", marker->markerName);
         marker->u.markerValue = NULL;
         free(result);
         result = NULL;

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -627,7 +627,9 @@ static int getAbsolutePatternMatch(FileDescriptor* fileDescriptor, GrepMarker* m
             marker->u.markerValue = result;
         }
     }
-
+    else{
+        marker->u.markerValue = result;
+    }
     T2Debug("%s --out\n", __FUNCTION__);
     return 0;
 }

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -614,8 +614,20 @@ static int getAbsolutePatternMatch(FileDescriptor* fileDescriptor, GrepMarker* m
     }
     memcpy(result, start, length);
     result[length] = '\0';
+    //TODO Remove the logic to limit the markers with value as 0 RDKB-62477
+    splitSuffix = strstr(marker->markerName, SPLITMARKER_SUFFIX);
+    if(splitSuffix != NULL && strcmp(splitSuffix, SPLITMARKER_SUFFIX) == 0)
+    {
+        if(strcmp(result, "0") == 0) {
+            marker->u.markerValue = NULL;
+            free(result);
+            result = NULL;
+        }
+        else{
+            marker->u.markerValue = result;
+        }
+    }
 
-    marker->u.markerValue = result;
     T2Debug("%s --out\n", __FUNCTION__);
     return 0;
 }


### PR DESCRIPTION
…ed to 8.3p2s1

Reason for change: To avoid getting the split markers with zero values in the dashboards
Test Procedure: There should not be crash and regression issues and split markers with zero values shouldn't be observed in the report Risks: Medium
Priority: P0