### PR TITLE
RDKB-62477:Clients related split markers with value as 0 after Upgrad…

### DIFF
--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -587,16 +587,16 @@ static int processPatternWithOptimizedFunction(const GrepMarker* marker, Vector*
     {
         // Get the last occurrence of the pattern in the memory-mapped data
         last_found = getAbsolutePatternMatch(filedescriptor, pattern);
+        //TODO Remove this logic to limit the markers with value as 0 after the dashboards are updated with the present framework RDKB-62477
+        if(last_found != NULL && strcmp(last_found, "0") == 0 )
+        {
+            T2Debug("Dropping the marker %s as the value is 0\n", header);
+            free(last_found);
+            last_found = NULL;
+        }
 
         if (last_found)
         {
-            //TODO Remove this logic to limit the markers with value as 0 after the dashboards are updated with the present framework RDKB-62477
-            if(strcmp(last_found, "0") == 0 )
-            {
-                T2Debug("Dropping the marker %s as the value is 0\n", header);
-                free(last_found);
-                last_found = NULL;
-            }
             // If a match is found, process it accordingly
             GrepResult* result = createGrepResultObj(header, last_found, trimParameter, regexParameter);
             if(last_found)

--- a/source/dcautil/dca.c
+++ b/source/dcautil/dca.c
@@ -543,20 +543,6 @@ static char* getAbsolutePatternMatch(FileDescriptor* fileDescriptor, const char*
     }
     memcpy(result, start, length);
     result[length] = '\0';
-
-    //TODO Remove this logic to limit the markers with value as 0 after the dashboards are updated with the present framework RDKB-62477
-    if(strcmp(result, "0") == 0 )
-    {
-        T2Debug("Dropping the marker %s as the value is 0\n", marker->markerName);
-        marker->u.markerValue = NULL;
-        free(result);
-        result = NULL;
-    }
-    else
-    {
-        marker->u.markerValue = result;
-    }
-
     T2Debug("%s --out\n", __FUNCTION__);
     return result;
 }
@@ -601,8 +587,16 @@ static int processPatternWithOptimizedFunction(const GrepMarker* marker, Vector*
     {
         // Get the last occurrence of the pattern in the memory-mapped data
         last_found = getAbsolutePatternMatch(filedescriptor, pattern);
+
         if (last_found)
         {
+            //TODO Remove this logic to limit the markers with value as 0 after the dashboards are updated with the present framework RDKB-62477
+            if(strcmp(last_found, "0") == 0 )
+            {
+                T2Debug("Dropping the marker %s as the value is 0\n", header);
+                free(last_found);
+                last_found = NULL;
+            }
             // If a match is found, process it accordingly
             GrepResult* result = createGrepResultObj(header, last_found, trimParameter, regexParameter);
             if(last_found)


### PR DESCRIPTION
…ed to 8.3p2s1

Reason for change: To avoid getting the split markers with zero values in the dashboards
Test Procedure: There should not be crash and regression issues and split markers with zero values shouldn't be observed in the report
Risks: Medium
Priority: P0