### PR TITLE
 RDKB-63722: Build fix for ssl crypto error in platforms with lower ssl version

### DIFF
--- a/source/protocol/http/multicurlinterface.c
+++ b/source/protocol/http/multicurlinterface.c
@@ -34,6 +34,7 @@
 #include <signal.h>
 #include <time.h>
 #include <openssl/err.h>
+#include <openssl/crypto.h>
 #include "multicurlinterface.h"
 #include "busInterface.h"
 #include "t2log_wrapper.h"

--- a/source/protocol/http/multicurlinterface.c
+++ b/source/protocol/http/multicurlinterface.c
@@ -686,7 +686,7 @@ T2ERROR http_pool_get(const char *url, char **response_data, bool enable_file_ou
         }
 #endif
         ERR_clear_error();
-        
+
         // Release all OpenSSL per-thread state (ERR stack, cached allocations).
         // Called at the end of the worker thread's HTTP operation to prevent
         // thread-local memory from accumulating across the daemon lifetime.
@@ -1102,7 +1102,7 @@ T2ERROR http_pool_post(const char *url, const char *payload)
 #endif
 
     // Release all OpenSSL per-thread state at the end of the worker thread's
-    // HTTP operation 
+    // HTTP operation
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
     OPENSSL_thread_stop();
 #else

--- a/source/protocol/http/multicurlinterface.c
+++ b/source/protocol/http/multicurlinterface.c
@@ -686,14 +686,16 @@ T2ERROR http_pool_get(const char *url, char **response_data, bool enable_file_ou
         }
 #endif
         ERR_clear_error();
-#if 0
+        
         // Release all OpenSSL per-thread state (ERR stack, cached allocations).
         // Called at the end of the worker thread's HTTP operation to prevent
         // thread-local memory from accumulating across the daemon lifetime.
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
         OPENSSL_thread_stop();
-#endif
-        // 1.0.x way to clean up per-thread state
+#else
         ERR_remove_thread_state(NULL);
+#endif
         release_pool_handle(idx);
         return T2ERROR_FAILURE;
     }
@@ -1100,9 +1102,12 @@ T2ERROR http_pool_post(const char *url, const char *payload)
 #endif
 
     // Release all OpenSSL per-thread state at the end of the worker thread's
-    // HTTP operation (see http_pool_get for rationale)
+    // HTTP operation 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     OPENSSL_thread_stop();
-
+#else
+    ERR_remove_thread_state(NULL);
+#endif
     // Note: When using LIBRDKCERTSEL_BUILD, pCertURI and pCertPC are owned by the
     // cert selector object and are freed when rdkcertselector_free() is called
     release_pool_handle(idx);

--- a/source/protocol/http/multicurlinterface.c
+++ b/source/protocol/http/multicurlinterface.c
@@ -686,12 +686,14 @@ T2ERROR http_pool_get(const char *url, char **response_data, bool enable_file_ou
         }
 #endif
         ERR_clear_error();
-
+#if 0
         // Release all OpenSSL per-thread state (ERR stack, cached allocations).
         // Called at the end of the worker thread's HTTP operation to prevent
         // thread-local memory from accumulating across the daemon lifetime.
         OPENSSL_thread_stop();
-
+#endif
+        // 1.0.x way to clean up per-thread state
+        ERR_remove_thread_state(NULL);
         release_pool_handle(idx);
         return T2ERROR_FAILURE;
     }


### PR DESCRIPTION
Reason for change: Compilation Error resolved  in XE2V2 Build  because this device build  was using an older version probable 1.0.x.  . Actually OPENSSL_thread_stop() was introduced  only in OpenSSL 1.1.0. We used this api for release all OpenSSL per-thread state (ERR stack, cached allocations) at the end of the worker  thread.  Its compatible with all RDKB device except 
Test Procedure: please refer the ticket comments
Risks: Medium