### PR TITLE
RDKEMW-16851: Increase Process name buffer length from 16 to 64 (#322)

### DIFF
--- a/source/dcautil/dcaproc.c
+++ b/source/dcautil/dcaproc.c
@@ -29,6 +29,7 @@
  * @{
  **/
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -94,7 +95,8 @@ int getProcUsage(char *processName, TopMarker* marker, char* filename)
         pid_t *pid = NULL;
         pid_t *temp = NULL;
         memset(&pInfo, '\0', sizeof(procMemCpuInfo));
-        memcpy(pInfo.processName, processName, strlen(processName) + 1);
+        strncpy(pInfo.processName, processName, BUF_LEN - 1);
+        pInfo.processName[BUF_LEN - 1] = '\0';
 
         T2Debug("Command for collecting process info : \n pidof %s", processName);
 #ifdef LIBSYSWRAPPER_BUILD
@@ -226,20 +228,20 @@ int getProcUsage(char *processName, TopMarker* marker, char* filename)
 
         pInfo.total_instance = index;
         pInfo.pid = pid;
+        if (marker->cpuValue)
+        {
+            free(marker->cpuValue);
+            marker->cpuValue = NULL;
+        }
+        if (marker->memValue)
+        {
+            free(marker->memValue);
+            marker->memValue = NULL;
+        }
         if(0 != getProcInfo(&pInfo, filename))
         {
             T2Debug("Process info - CPU: %s, Memory: %s \n", pInfo.cpuUse, pInfo.memUse);
-
-            if (marker->cpuValue)
-            {
-                free(marker->cpuValue);
-            }
             marker->cpuValue = strdup(pInfo.cpuUse);
-
-            if (marker->memValue)
-            {
-                free(marker->memValue);
-            }
             marker->memValue = strdup(pInfo.memUse);
 
             ret = 1;
@@ -533,15 +535,24 @@ int getCPUInfo(procMemCpuInfo *pInfo, char* filename)
     char top_op[2048] = { '\0' };
     int cmd_option = 0;
     int normalize = 1;
+    int read_from_file = 0;
 
     if(pInfo == NULL)
     {
 
         return 0;
     }
-    if((filename != NULL) && (access(filename, F_OK) != 0))
+    if((filename != NULL) && (access(filename, F_OK) == 0))
     {
-        T2Debug("%s ++in the savad temp log %s is not available \n", __FUNCTION__, filename);
+        /* TOPTEMP file is available - open directly in C, no shell spawning needed */
+        T2Debug("%s ++in the saved temp log %s is available \n", __FUNCTION__, filename);
+        inFp = fopen(filename, "r");
+        normalize = TOPITERATION;
+        read_from_file = 1;
+    }
+    else
+    {
+        T2Debug("%s ++in the saved temp log %s is not available \n", __FUNCTION__, filename);
         /* Check Whether -c option is supported */
 #ifdef LIBSYSWRAPPER_BUILD
         ret = v_secure_system(" top -c -n 1 2> /dev/null 1> /dev/null");
@@ -554,53 +565,29 @@ int getCPUInfo(procMemCpuInfo *pInfo, char* filename)
         }
 
 #ifdef INTEL
-        /* Format Use:  `top n 1 | grep Receiver` */
-        if ( 1 == cmd_option )
-        {
+        /* Format Use:  `top n 1 (-c)` */
 #ifdef LIBSYSWRAPPER_BUILD
-            inFp = v_secure_popen("r", "top -n 1 -c | grep -v grep |grep -i '%s'", pInfo->processName);
+        inFp = v_secure_popen("r", "top -n 1 %s", (cmd_option == 1) ? "-c" : "");
 #else
-            sprintf(command, "top -n 1 -c | grep -v grep |grep -i '%s'", pInfo->processName);
-            inFp = popen(command, "r");
+        snprintf(command, CMD_LEN, "top -n 1 %s", (cmd_option == 1) ? "-c" : "");
+        inFp = popen(command, "r");
 #endif
-        }
-        else
-        {
-#ifdef LIBSYSWRAPPER_BUILD
-            inFp = v_secure_popen("r", "top -n 1 | grep -i '%s'", pInfo->processName);
-#else
-            sprintf(command, "top -n 1 | grep -i '%s'", pInfo->processName);
-            inFp = popen(command, "r");
-#endif
-        }
 #else
         /* ps -C Receiver -o %cpu -o %mem */
         //sprintf(command, "ps -C '%s' -o %%cpu -o %%mem | sed 1d", pInfo->processName);
 #ifdef LIBSYSWRAPPER_BUILD
-        inFp = v_secure_popen("r", "top -b -n 1 %s | grep -v grep | grep -i '%s'", (cmd_option == 1) ? "-c" : "", pInfo->processName);
+        inFp = v_secure_popen("r", "top -b -n 1 %s", (cmd_option == 1) ? "-c" : "");
 #else
-        snprintf(command, CMD_LEN, "top -b -n 1 %s | grep -v grep | grep -i '%s'", (cmd_option == 1) ? "-c" : "", pInfo->processName);
+        snprintf(command, CMD_LEN, "top -b -n 1 %s", (cmd_option == 1) ? "-c" : "");
         inFp = popen(command, "r");
 #endif
 
 #endif
-    }
-    else
-    {
-        T2Debug("%s ++in the savad temp log %s is available \n", __FUNCTION__, filename);
-#ifdef LIBSYSWRAPPER_BUILD
-        inFp = v_secure_popen("r", "cat %s |grep -i '%s'", TOPTEMP, pInfo->processName);
-#else
-        snprintf(command, sizeof(command), "cat %s |grep -i '%s'", filename, pInfo->processName);
-        inFp = popen(command, "r");
-#endif
-        normalize = TOPITERATION;
-
     }
 
     if(!(inFp))
     {
-        T2Debug("failed in open v_scure_popen pipe! ret %d\n", pclose_ret);
+        T2Debug("failed in open v_secure_popen pipe! ret %d\n", pclose_ret);
         return 0;
     }
 
@@ -608,6 +595,13 @@ int getCPUInfo(procMemCpuInfo *pInfo, char* filename)
 #ifdef INTEL
     while(fgets(top_op, 2048, inFp) != NULL)
     {
+        /* match by process name (case-insensitive), PID as fallback */
+        if(strcasestr(top_op, pInfo->processName) == NULL)
+        {
+            int line_pid = 0;
+            if(sscanf(top_op, "%d", &line_pid) != 1 || line_pid != pInfo->pid[0])
+                continue;
+        }
         if(sscanf(top_op, "%s %s %s %s %s %s %s %s", var1, var2, var3, var4, var5, var6, var7, var8) == 8)
         {
             total_cpu_usage += atof(var7);
@@ -618,6 +612,13 @@ int getCPUInfo(procMemCpuInfo *pInfo, char* filename)
 #else
     while(fgets(top_op, 2048, inFp) != NULL)
     {
+        /* match by process name (case-insensitive), PID as fallback */
+        if(strcasestr(top_op, pInfo->processName) == NULL)
+        {
+            int line_pid = 0;
+            if(sscanf(top_op, "%d", &line_pid) != 1 || line_pid != pInfo->pid[0])
+                continue;
+        }
         if(sscanf(top_op, "%16s %16s %16s %16s %16s %16s %16s %512s %512s %512s", var1, var2, var3, var4, var5, var6, var7, var8, var9, var10) == 10)
         {
             total_cpu_usage += atof(var9);
@@ -628,19 +629,24 @@ int getCPUInfo(procMemCpuInfo *pInfo, char* filename)
 
     snprintf(pInfo->cpuUse, sizeof(pInfo->cpuUse), "%.1lf", (float)(total_cpu_usage / normalize));
     T2Debug("calculated CPU total value : %f Normalized value : %.1lf\n", total_cpu_usage, (float)(total_cpu_usage / normalize));
-#ifdef LIBSYSWRAPPER_BUILD
-    pclose_ret = v_secure_pclose(inFp);
-#else
-    pclose_ret = pclose(inFp);
-#endif
-
-    if(pclose_ret != 0)
+    if(read_from_file)
     {
-        T2Debug("failed in closing pipe! ret %d\n", pclose_ret);
+        fclose(inFp);
     }
-    return ret;
+    else
+    {
+#ifdef LIBSYSWRAPPER_BUILD
+        pclose_ret = v_secure_pclose(inFp);
+#else
+        pclose_ret = pclose(inFp);
+#endif
+        if(pclose_ret != 0)
+        {
+            T2Debug("failed in closing pipe! ret %d\n", pclose_ret);
+        }
+    }
     T2Debug("--out %s", __FUNCTION__);
-
+    return ret;
 }
 
 #else //ENABLE_RDKC_SUPPORT & ENABLE_RDKB_SUPPORT


### PR DESCRIPTION
* DELIA-70280: Box boot up time is extended due to Privacy control hangs (#305)

* RDKEMW-15927 ,RDKEMW-15007 : [APACA/Xione DE] rbus self-deadlock in XConf privacy mode fetch causing ~188s T2 init delay

Reason for change: When UserSettings sets privacy mode to DO_NOT_SHARE during boot, the rbus SET handler (t2PropertyDataSetHandler) runs synchronously on the single rbus callback thread — executing deleteAllProfiles() with pthread_join, disk I/O, and XConf client restart.

The restarted XConf thread calls appendRequestParams() which uses getParameterValue(PRIVACYMODES_RFC) to fetch privacy mode. This issues rbus_get() on T2's own bus handle, requiring the same rbus callback thread that is already blocked processing the SET handler. This creates a self-deadlock with a 15s rbus timeout per attempt, compounded by XCONF_RETRY_TIMEOUT (180s), stalling T2 initialization.

Cascading effect: While T2 is stalled, external callers (e.g. WPEFramework SystemServices plugin) invoking t2_event_s() block 15s each on rbus_getUint(Telemetry.OperationalStatus), delaying the dispatch thread by ~188s and blocking sendNotify() for EVT_ONSYSTEMPOWERSTATECHANGED.

Fix:
- xconfclient.c: Replace getParameterValue(PRIVACYMODES_RFC) with direct getPrivacyMode() call from privacycontrol library. The platform implementation (provided via meta layer bbappend) reads from a local in-memory cache (PRIVACY_STATE), with fallback to Thunder JSON-RPC (local HTTP) and persistent storage — none of which use rbus, eliminating the self-deadlock. `
- xconf-client/Makefile.am: Add privacycontrol include path and build dependency when IS_PRIVACYCONTROL_ENABLED is set.

- telemetry_busmessage_sender.c: Add fast-fail file marker check (T2_COMPONENT_READY) before rbus_getUint() in isCachingRequired() to avoid 15s blocking timeout when T2 is not yet ready. Test Procedure: please refer the ticket comments
Risks: Medium


* Addressed the L1 Test cases failure

* RDKEMW-15927, RDKEMW-15007 : [APACA/Xione DE] Fix RBUS handler starvation and race condition on privacyModeVal

Reason for change: When UserSettings sets privacy mode to DO_NOT_SHARE during boot, the rbus SET handler (t2PropertyDataSetHandler) runs synchronously on the single rbus callback thread — executing deleteAllProfiles() with pthread_join, disk I/O, and XConf client restart.

The restarted XConf thread calls appendRequestParams() which uses getParameterValue(PRIVACYMODES_RFC) to fetch privacy mode. This issues rbus_get() on T2's own bus handle, requiring the same rbus callback thread that is already blocked processing the SET handler. This creates a self-deadlock with a 15s rbus timeout per attempt, compounded by XCONF_RETRY_TIMEOUT (180s), stalling T2 initialization.

Additionally, privacyModeVal global pointer has no mutex protection, allowing use-after-free and NULL dereference under concurrent SET/GET operations during stress scenarios.

Cascading effect: While T2 is stalled, external callers (e.g. WPEFramework SystemServices plugin) invoking t2_event_s() block 15s each on rbus_getUint(Telemetry.OperationalStatus), delaying the dispatch thread by ~188s and blocking sendNotify() for EVT_ONSYSTEMPOWERSTATECHANGED. Under concurrent privacy mode toggling, PROVIDER_NOT_RESPONDING with 26+ messages queued and dropped, telemetry events fall back to file caching.

Fix:
- rbusInterface.c: Add privacyModeMutex (PTHREAD_MUTEX_INITIALIZER) to serialize all reads/writes of privacyModeVal in SET and GET handlers, preventing use-after-free and NULL dereference.

- rbusInterface.c: Add privacyModeCallbackWorker() detached thread. The SET handler now validates input, updates privacyModeVal under mutex, calls setPrivacyMode() for persistence, then dispatches heavy callbacks (mprofilesDeleteCallBack, privacyModesDoNotShareCallBack) to the worker thread. RBUS handler returns immediately, preventing handler thread starvation and cascading 180s timeout loops.

- xconfclient.c: Replace getParameterValue(PRIVACYMODES_RFC) with direct getPrivacyMode() call from privacycontrol library. The platform implementation (provided via meta layer bbappend) reads from a local in-memory cache (PRIVACY_STATE), with fallback to Thunder JSON-RPC (local HTTP) and persistent storage — none of which use rbus, eliminating the self-deadlock.

- xconf-client/Makefile.am: Add privacycontrol include path and build dependency when IS_PRIVACYCONTROL_ENABLED is set. Add else branch for libxconfclient_la_CFLAGS to define the variable in all automake conditions, fixing autoreconf failure.

- telemetry_busmessage_sender.c: Add fast-fail file marker check (T2_COMPONENT_READY) before rbus_getUint() in isCachingRequired() to avoid blocking on rbus timeout when T2 is not ready.

- persistence.c: Change rm -f to rm -rf in clearPersistenceFolder() non-LIBSYSWRAPPER path. PRIVACYMODE_PATH is a directory, not a file; rm -f fails silently leaving stale persistence data.

Test Procedure: Concurrent stress test with multiple privacy mode toggles (SHARE/DO_NOT_SHARE via curl JSON-RPC), telemetry marker submissions (telemetry2_0_client), rbuscli reads, and SIGUSR1 signal — all running simultaneously in background.
Risks: Medium


* Addressed the shibu review comments

* Addressed the empty check on path  on fetchLocalConfigs and clearPersistenceFolder

* Apply suggestion from @Copilot



* Apply suggestion from @Copilot



* Removed the extra space for addressed the style formatting

* Addressed the astyle format issue

* Fix dangling pointer in rbusInterface.c GET handler: call rbusValue_SetString after ownership transfer

Agent-Logs-Url: https://github.com/rdkcentral/telemetry/sessions/d5b743ff-3289-4141-b51a-399971064c4c



---------






* Changelog updates for hotfix 1.8.5v1

* BES1-941: Update dcautil.h

* Update dcaproc.c

* Update dcaproc.c

* Update dcaproc.c

* Update dcaproc.c

* Update dcaproc.c

* BES1-941: Update dcaproc.c

* BES1-941: Update dcaproc.c

* BES1-941: Update dcaproc.c

* BES1-941: Update reportgen.c

* BES1-941: Update dcaproc.c

* RDKEMW-16851: Update dcautil.h

* RDKEMW-16851: Update dcaproc.c

* RDKEMW-16851: Update dcaproc.c

* RDKEMW-16851: Revert Info log lines to debug log lines



* Initial plan

* RDKEMW-16851: Update dcaproc.c



* RDKEMW-16851: Update dcaproc.c



---------