### PR TITLE
RDKB-64487: TSAN fixes for various issues

### DIFF
--- a/source/bulkdata/profile.c
+++ b/source/bulkdata/profile.c
@@ -1266,12 +1266,22 @@ T2ERROR disableProfile(const char *profileName, bool *isDeleteRequired)
     }
     else
     {
-        /* Protect enable flag with reuseThreadMutex so CollectAndReport thread
-         * sees the update consistently (it reads enable under this mutex). */
-        pthread_mutex_lock(&profile->reuseThreadMutex);
-        profile->enable = false;
-        pthread_cond_signal(&profile->reuseThread);
-        pthread_mutex_unlock(&profile->reuseThreadMutex);
+        /* Only touch reuseThreadMutex/reuseThread when the report thread
+         * exists and therefore owns valid synchronization primitives.
+         * reuseThreadMutex is initialized inside CollectAndReport() and
+         * destroyed when that thread exits, so accessing it when the thread
+         * has not started or has already exited is undefined behavior. */
+        if (profile->threadExists)
+        {
+            pthread_mutex_lock(&profile->reuseThreadMutex);
+            profile->enable = false;
+            pthread_cond_signal(&profile->reuseThread);
+            pthread_mutex_unlock(&profile->reuseThreadMutex);
+        }
+        else
+        {
+            profile->enable = false;
+        }
     }
 #ifdef PERSIST_LOG_MON_REF
     removeProfileFromDisk(SEEKFOLDER, profile->name);

--- a/source/bulkdata/profile.c
+++ b/source/bulkdata/profile.c
@@ -1266,7 +1266,12 @@ T2ERROR disableProfile(const char *profileName, bool *isDeleteRequired)
     }
     else
     {
+        /* Protect enable flag with reuseThreadMutex so CollectAndReport thread
+         * sees the update consistently (it reads enable under this mutex). */
+        pthread_mutex_lock(&profile->reuseThreadMutex);
         profile->enable = false;
+        pthread_cond_signal(&profile->reuseThread);
+        pthread_mutex_unlock(&profile->reuseThreadMutex);
     }
 #ifdef PERSIST_LOG_MON_REF
     removeProfileFromDisk(SEEKFOLDER, profile->name);

--- a/source/protocol/rbusMethod/rbusmethodinterface.c
+++ b/source/protocol/rbusMethod/rbusmethodinterface.c
@@ -117,27 +117,39 @@ T2ERROR sendReportsOverRBUSMethod(char *methodName, Vector* inputParams, char* p
 
     pthread_once(&rbusMethodMutexOnce, sendOverRBUSMethodInit);
 
-    /* Initialize state under lock, then release before the async call.
-     * The callback will lock, set results, signal, and unlock — so every
-     * thread only unlocks a mutex it locked itself (no cross-thread unlock). */
+    /* Hold rbusMethodMutex across the entire async-call + wait sequence.
+     * This serializes concurrent callers so shared globals (isRbusMethod,
+     * rbusMethodCallbackDone) cannot be clobbered by a second caller while
+     * an async invocation is in flight.  The callback can still acquire the
+     * mutex because pthread_cond_timedwait atomically releases it. */
     pthread_mutex_lock(&rbusMethodMutex);
     isRbusMethod = false ;
     rbusMethodCallbackDone = false;
-    pthread_mutex_unlock(&rbusMethodMutex);
 
     if ( T2ERROR_SUCCESS == rbusMethodCaller(methodName, &inParams, payload, &asyncMethodHandler))
     {
         struct timespec ts;
-        clock_gettime(CLOCK_REALTIME, &ts);
+        if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
+        {
+            T2Error("clock_gettime failed: %s (errno=%d)\n", strerror(errno), errno);
+            pthread_mutex_unlock(&rbusMethodMutex);
+            rbusObject_Release(inParams);
+            T2Debug("%s --out\n", __FUNCTION__);
+            return T2ERROR_FAILURE;
+        }
         ts.tv_sec += MAX_RETRY_ATTEMPTS * 2;  /* Total timeout: 10 seconds */
 
-        pthread_mutex_lock(&rbusMethodMutex);
         while (!rbusMethodCallbackDone)
         {
             int rc = pthread_cond_timedwait(&rbusMethodCond, &rbusMethodMutex, &ts);
             if(rc == ETIMEDOUT)
             {
                 T2Error("Timed out waiting for rbus method callback. Giving up\n");
+                break;
+            }
+            else if(rc != 0)
+            {
+                T2Error("pthread_cond_timedwait failed: %s (rc=%d)\n", strerror(rc), rc);
                 break;
             }
         }
@@ -156,6 +168,10 @@ T2ERROR sendReportsOverRBUSMethod(char *methodName, Vector* inputParams, char* p
             /* Timed out — callback never fired */
             ret = T2ERROR_NO_RBUS_METHOD_PROVIDER;
         }
+        pthread_mutex_unlock(&rbusMethodMutex);
+    }
+    else
+    {
         pthread_mutex_unlock(&rbusMethodMutex);
     }
     rbusObject_Release(inParams);

--- a/source/protocol/rbusMethod/rbusmethodinterface.c
+++ b/source/protocol/rbusMethod/rbusmethodinterface.c
@@ -39,6 +39,7 @@
 static pthread_once_t rbusMethodMutexOnce = PTHREAD_ONCE_INIT;
 static pthread_mutex_t rbusMethodMutex;
 static pthread_cond_t rbusMethodCond;
+static clockid_t rbusMethodCondClock = CLOCK_REALTIME;
 static bool rbusMethodCallbackDone = false;
 static bool isRbusMethod = false ;
 
@@ -49,21 +50,32 @@ static void sendOverRBUSMethodInit()
 
     pthread_mutex_init(&rbusMethodMutex, NULL);
     /* Use CLOCK_MONOTONIC so NTP/time-sync adjustments don't cause
-     * the timed wait to expire too early or block too long. */
+     * the timed wait to expire too early or block too long.
+     * Track the actual clock so the timed-wait side always matches. */
     ret = pthread_condattr_init(&condattr);
     if (ret != 0)
     {
         T2Error("pthread_condattr_init failed: %s\n", strerror(ret));
-        /* Fall back to default clock */
         pthread_cond_init(&rbusMethodCond, NULL);
+        rbusMethodCondClock = CLOCK_REALTIME;
         return;
     }
     ret = pthread_condattr_setclock(&condattr, CLOCK_MONOTONIC);
     if (ret != 0)
     {
         T2Error("pthread_condattr_setclock failed: %s\n", strerror(ret));
+        rbusMethodCondClock = CLOCK_REALTIME;
     }
-    pthread_cond_init(&rbusMethodCond, &condattr);
+    else
+    {
+        rbusMethodCondClock = CLOCK_MONOTONIC;
+    }
+    if (pthread_cond_init(&rbusMethodCond, &condattr) != 0)
+    {
+        T2Error("pthread_cond_init failed, retrying with defaults\n");
+        pthread_cond_init(&rbusMethodCond, NULL);
+        rbusMethodCondClock = CLOCK_REALTIME;
+    }
     if (pthread_condattr_destroy(&condattr) != 0)
     {
         T2Error("pthread_condattr_destroy failed\n");
@@ -151,7 +163,7 @@ T2ERROR sendReportsOverRBUSMethod(char *methodName, Vector* inputParams, char* p
     if ( T2ERROR_SUCCESS == rbusMethodCaller(methodName, &inParams, payload, &asyncMethodHandler))
     {
         struct timespec ts;
-        if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+        if (clock_gettime(rbusMethodCondClock, &ts) != 0)
         {
             T2Error("clock_gettime failed: %s (errno=%d)\n", strerror(errno), errno);
             pthread_mutex_unlock(&rbusMethodMutex);

--- a/source/protocol/rbusMethod/rbusmethodinterface.c
+++ b/source/protocol/rbusMethod/rbusmethodinterface.c
@@ -44,8 +44,14 @@ static bool isRbusMethod = false ;
 
 static void sendOverRBUSMethodInit()
 {
+    pthread_condattr_t condattr;
     pthread_mutex_init(&rbusMethodMutex, NULL);
-    pthread_cond_init(&rbusMethodCond, NULL);
+    /* Use CLOCK_MONOTONIC so NTP/time-sync adjustments don't cause
+     * the timed wait to expire too early or block too long. */
+    pthread_condattr_init(&condattr);
+    pthread_condattr_setclock(&condattr, CLOCK_MONOTONIC);
+    pthread_cond_init(&rbusMethodCond, &condattr);
+    pthread_condattr_destroy(&condattr);
 }
 
 static void asyncMethodHandler(rbusHandle_t handle, char const* methodName, rbusError_t retStatus, rbusObject_t params)
@@ -129,7 +135,7 @@ T2ERROR sendReportsOverRBUSMethod(char *methodName, Vector* inputParams, char* p
     if ( T2ERROR_SUCCESS == rbusMethodCaller(methodName, &inParams, payload, &asyncMethodHandler))
     {
         struct timespec ts;
-        if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
+        if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
         {
             T2Error("clock_gettime failed: %s (errno=%d)\n", strerror(errno), errno);
             pthread_mutex_unlock(&rbusMethodMutex);

--- a/source/protocol/rbusMethod/rbusmethodinterface.c
+++ b/source/protocol/rbusMethod/rbusmethodinterface.c
@@ -45,13 +45,29 @@ static bool isRbusMethod = false ;
 static void sendOverRBUSMethodInit()
 {
     pthread_condattr_t condattr;
+    int ret;
+
     pthread_mutex_init(&rbusMethodMutex, NULL);
     /* Use CLOCK_MONOTONIC so NTP/time-sync adjustments don't cause
      * the timed wait to expire too early or block too long. */
-    pthread_condattr_init(&condattr);
-    pthread_condattr_setclock(&condattr, CLOCK_MONOTONIC);
+    ret = pthread_condattr_init(&condattr);
+    if (ret != 0)
+    {
+        T2Error("pthread_condattr_init failed: %s\n", strerror(ret));
+        /* Fall back to default clock */
+        pthread_cond_init(&rbusMethodCond, NULL);
+        return;
+    }
+    ret = pthread_condattr_setclock(&condattr, CLOCK_MONOTONIC);
+    if (ret != 0)
+    {
+        T2Error("pthread_condattr_setclock failed: %s\n", strerror(ret));
+    }
     pthread_cond_init(&rbusMethodCond, &condattr);
-    pthread_condattr_destroy(&condattr);
+    if (pthread_condattr_destroy(&condattr) != 0)
+    {
+        T2Error("pthread_condattr_destroy failed\n");
+    }
 }
 
 static void asyncMethodHandler(rbusHandle_t handle, char const* methodName, rbusError_t retStatus, rbusObject_t params)

--- a/source/protocol/rbusMethod/rbusmethodinterface.c
+++ b/source/protocol/rbusMethod/rbusmethodinterface.c
@@ -26,6 +26,8 @@
 #include <string.h>
 #include <ifaddrs.h>
 #include <stdbool.h>
+#include <time.h>
+#include <errno.h>
 
 #include "reportgen.h"
 #include "rbusInterface.h"
@@ -36,12 +38,14 @@
 
 static pthread_once_t rbusMethodMutexOnce = PTHREAD_ONCE_INIT;
 static pthread_mutex_t rbusMethodMutex;
-
+static pthread_cond_t rbusMethodCond;
+static bool rbusMethodCallbackDone = false;
 static bool isRbusMethod = false ;
 
 static void sendOverRBUSMethodInit()
 {
     pthread_mutex_init(&rbusMethodMutex, NULL);
+    pthread_cond_init(&rbusMethodCond, NULL);
 }
 
 static void asyncMethodHandler(rbusHandle_t handle, char const* methodName, rbusError_t retStatus, rbusObject_t params)
@@ -50,10 +54,11 @@ static void asyncMethodHandler(rbusHandle_t handle, char const* methodName, rbus
     (void) params;
 
     T2Info("T2 asyncMethodHandler called: %s with return error code  = %s \n", methodName, rbusError_ToString(retStatus));
-    //Note: The mutex synchronization is handled by the caller (sendReportsOverRBUSMethod)
-    //which locks the mutex before calling rbusMethodCaller and uses pthread_mutex_trylock
-    //to wait for this async callback to complete. This callback updates isRbusMethod
-    //without additional locking as the caller manages the synchronization.
+
+    /* Lock the mutex, update result, signal the waiting caller, then unlock.
+     * This ensures no cross-thread unlock (which is UB for default mutexes)
+     * and provides proper memory visibility for isRbusMethod. */
+    pthread_mutex_lock(&rbusMethodMutex);
     if(retStatus == RBUS_ERROR_SUCCESS)
     {
         isRbusMethod = true ;
@@ -63,6 +68,8 @@ static void asyncMethodHandler(rbusHandle_t handle, char const* methodName, rbus
         T2Error("Unable to send data over method %s \n", methodName) ;
         isRbusMethod = false ;
     }
+    rbusMethodCallbackDone = true;
+    pthread_cond_signal(&rbusMethodCond);
     pthread_mutex_unlock(&rbusMethodMutex);
 }
 
@@ -109,49 +116,46 @@ T2ERROR sendReportsOverRBUSMethod(char *methodName, Vector* inputParams, char* p
     rbusValue_Release(value);
 
     pthread_once(&rbusMethodMutexOnce, sendOverRBUSMethodInit);
+
+    /* Initialize state under lock, then release before the async call.
+     * The callback will lock, set results, signal, and unlock — so every
+     * thread only unlocks a mutex it locked itself (no cross-thread unlock). */
     pthread_mutex_lock(&rbusMethodMutex);
     isRbusMethod = false ;
-    bool mutexHeld = true;  /* Track lock ownership to avoid unlock-of-unlocked */
+    rbusMethodCallbackDone = false;
+    pthread_mutex_unlock(&rbusMethodMutex);
+
     if ( T2ERROR_SUCCESS == rbusMethodCaller(methodName, &inParams, payload, &asyncMethodHandler))
     {
-        /* rbusMethodCaller succeeded: asyncMethodHandler will unlock rbusMethodMutex
-         * when the async callback fires.  We no longer hold the lock. */
-        mutexHeld = false;
-        int retry_count = 0;
-        while (retry_count < MAX_RETRY_ATTEMPTS)
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += MAX_RETRY_ATTEMPTS * 2;  /* Total timeout: 10 seconds */
+
+        pthread_mutex_lock(&rbusMethodMutex);
+        while (!rbusMethodCallbackDone)
         {
-            if(!(pthread_mutex_trylock(&rbusMethodMutex)))  // locking the rbusMethodMutex, in asyncMethodHandler mutex unlock is present
+            int rc = pthread_cond_timedwait(&rbusMethodCond, &rbusMethodMutex, &ts);
+            if(rc == ETIMEDOUT)
             {
-                mutexHeld = true;
-                if (isRbusMethod)
-                {
-                    T2Info("Return status of send via rbusMethod is success \n " );
-                    ret = T2ERROR_SUCCESS ;
-                }
-                else
-                {
-                    T2Info("Return status of send via rbusMethod is failure \n " );
-                    ret = T2ERROR_NO_RBUS_METHOD_PROVIDER;
-                }
+                T2Error("Timed out waiting for rbus method callback. Giving up\n");
                 break;
             }
-            else
-            {
-                retry_count++;
-                sleep(2);
-                if(retry_count == MAX_RETRY_ATTEMPTS)
-                {
-                    T2Error("Max attempts reached for rbusmethodlock. Giving up\n");
-                    ret = T2ERROR_NO_RBUS_METHOD_PROVIDER;
-                }
-            }
         }
-    }
-    /* Only unlock if we currently hold the mutex.  When rbusMethodCaller fails,
-     * we still hold it from the initial lock above.  When it succeeds, the
-     * asyncMethodHandler unlocks it, and we only re-acquire via trylock. */
-    if(mutexHeld)
-    {
+        if (rbusMethodCallbackDone && isRbusMethod)
+        {
+            T2Info("Return status of send via rbusMethod is success\n");
+            ret = T2ERROR_SUCCESS ;
+        }
+        else if (rbusMethodCallbackDone)
+        {
+            T2Info("Return status of send via rbusMethod is failure\n");
+            ret = T2ERROR_NO_RBUS_METHOD_PROVIDER;
+        }
+        else
+        {
+            /* Timed out — callback never fired */
+            ret = T2ERROR_NO_RBUS_METHOD_PROVIDER;
+        }
         pthread_mutex_unlock(&rbusMethodMutex);
     }
     rbusObject_Release(inParams);

--- a/source/protocol/rbusMethod/rbusmethodinterface.c
+++ b/source/protocol/rbusMethod/rbusmethodinterface.c
@@ -111,13 +111,18 @@ T2ERROR sendReportsOverRBUSMethod(char *methodName, Vector* inputParams, char* p
     pthread_once(&rbusMethodMutexOnce, sendOverRBUSMethodInit);
     pthread_mutex_lock(&rbusMethodMutex);
     isRbusMethod = false ;
+    bool mutexHeld = true;  /* Track lock ownership to avoid unlock-of-unlocked */
     if ( T2ERROR_SUCCESS == rbusMethodCaller(methodName, &inParams, payload, &asyncMethodHandler))
     {
+        /* rbusMethodCaller succeeded: asyncMethodHandler will unlock rbusMethodMutex
+         * when the async callback fires.  We no longer hold the lock. */
+        mutexHeld = false;
         int retry_count = 0;
         while (retry_count < MAX_RETRY_ATTEMPTS)
         {
             if(!(pthread_mutex_trylock(&rbusMethodMutex)))  // locking the rbusMethodMutex, in asyncMethodHandler mutex unlock is present
             {
+                mutexHeld = true;
                 if (isRbusMethod)
                 {
                     T2Info("Return status of send via rbusMethod is success \n " );
@@ -133,24 +138,22 @@ T2ERROR sendReportsOverRBUSMethod(char *methodName, Vector* inputParams, char* p
             else
             {
                 retry_count++;
-                /*
-                 * NOTE: CID=190391 is a false positive.
-                 * The rbusMethodMutex is already unlocked within asyncMethodHandler.
-                 * This code path handles the scenario where locking fails again,
-                 * so there is no need to address or fix this warning.
-                 */
-                sleep(2); // giving 2 seconds sleep for 5 times which will be equal to waiting for RBUS_METHOD_TIMEOUT value // Removing the pthread_mutex_unlock before sleep as rbusmethodmutex will be unlocked by asyncMethodHandler.
-                if(retry_count == 5)
+                sleep(2);
+                if(retry_count == MAX_RETRY_ATTEMPTS)
                 {
-                    T2Error("Max attempts reached for rbusmethodlock. Unlocking it\n");
+                    T2Error("Max attempts reached for rbusmethodlock. Giving up\n");
                     ret = T2ERROR_NO_RBUS_METHOD_PROVIDER;
                 }
             }
         }
     }
-    /*rbusMethodMutex is locked before rbusMethodCaller if rbusMethodCaller function returns failure rbusMethodMutex will be unlocked here and in second case if rbusMethodCaller returns success then in asyncMethodHandler already mutex unlock is done which unlocks the rbusMethodMutex
-      lock done above so adding another lock inside rbusMethodCaller if loop for rbusMethodMutex which later gets unlocked by the below mutex unlock.*/
-    pthread_mutex_unlock(&rbusMethodMutex);
+    /* Only unlock if we currently hold the mutex.  When rbusMethodCaller fails,
+     * we still hold it from the initial lock above.  When it succeeds, the
+     * asyncMethodHandler unlocks it, and we only re-acquire via trylock. */
+    if(mutexHeld)
+    {
+        pthread_mutex_unlock(&rbusMethodMutex);
+    }
     rbusObject_Release(inParams);
 
     T2Debug("%s --out\n", __FUNCTION__);

--- a/source/scheduler/scheduler.c
+++ b/source/scheduler/scheduler.c
@@ -263,7 +263,13 @@ void* TimeoutThread(void *arg)
                 T2Info("Waiting for %d sec for next TIMEOUT for profile as reporting interval is taken - %s\n", tProfile->timeOutDuration, tProfile->name);
             }
         }
+        /* Release tMutex before calling notifySchedulerstartcb to avoid
+         * lock-order-inversion: this thread holds tMutex and the callback
+         * acquires profileListLock(wr), while other threads hold
+         * profileListLock(rd) and then try to acquire tMutex. */
+        pthread_mutex_unlock(&tProfile->tMutex);
         notifySchedulerstartcb(tProfile->name, true);
+        pthread_mutex_lock(&tProfile->tMutex);
         //When first reporting interval is given waiting for first report int vale
         if(tProfile->firstreportint > 0 && tProfile->firstexecution == true )
         {

--- a/source/scheduler/scheduler.c
+++ b/source/scheduler/scheduler.c
@@ -266,10 +266,28 @@ void* TimeoutThread(void *arg)
         /* Release tMutex before calling notifySchedulerstartcb to avoid
          * lock-order-inversion: this thread holds tMutex and the callback
          * acquires profileListLock(wr), while other threads hold
-         * profileListLock(rd) and then try to acquire tMutex. */
-        pthread_mutex_unlock(&tProfile->tMutex);
-        notifySchedulerstartcb(tProfile->name, true);
-        pthread_mutex_lock(&tProfile->tMutex);
+         * profileListLock(rd) and then try to acquire tMutex.
+         * Copy name to a local buffer first — tProfile->name could be freed
+         * by freeSchedulerProfile on another thread while tMutex is released. */
+        char *profileNameCopy = strdup(tProfile->name);
+        if(pthread_mutex_unlock(&tProfile->tMutex) != 0)
+        {
+            T2Error("tProfile Mutex unlock failed before notifySchedulerstartcb\n");
+        }
+        if(profileNameCopy)
+        {
+            notifySchedulerstartcb(profileNameCopy, true);
+            free(profileNameCopy);
+        }
+        else
+        {
+            T2Error("Failed to allocate profileNameCopy for notifySchedulerstartcb\n");
+        }
+        if(pthread_mutex_lock(&tProfile->tMutex) != 0)
+        {
+            T2Error("tProfile Mutex lock failed after notifySchedulerstartcb\n");
+            return NULL;
+        }
         //When first reporting interval is given waiting for first report int vale
         if(tProfile->firstreportint > 0 && tProfile->firstexecution == true )
         {

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -139,35 +139,6 @@ static void terminate()
     }
 
 }
-static void _print_stack_backtrace(void)
-{
-#ifdef __GNUC__
-#ifndef _BUILD_ANDROID
-#ifdef __GLIBC__
-    void* tracePtrs[100];
-    char** funcNames = NULL;
-    int i, count = 0;
-
-    count = backtrace( tracePtrs, 100 );
-    backtrace_symbols_fd( tracePtrs, count, 2 );
-
-    funcNames = backtrace_symbols( tracePtrs, count );
-
-    if ( funcNames )
-    {
-        // Print the stack trace
-        for( i = 0; i < count; i++ )
-        {
-            printf("%s\n", funcNames[i] );
-        }
-
-        // Free the string pointers
-        free( funcNames );
-    }
-#endif
-#endif
-#endif
-}
 
 void sig_handler(int sig, siginfo_t* info, void* uc)
 {
@@ -188,7 +159,7 @@ void sig_handler(int sig, siginfo_t* info, void* uc)
 
     /* POSIX async-signal-safe: only set flags here.
      * The main loop polls these flags and performs the actual work. */
-    if ( sig == SIGINT || sig == SIGTERM || sig == SIGKILL )
+    if ( sig == SIGINT || sig == SIGTERM )
     {
         g_sig_shutdown = 1;
     }

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -71,6 +71,7 @@ static pid_t DAEMONPID; //static varible store the Main Pid
  * volatile sig_atomic_t is the only type guaranteed safe from signal context. */
 static volatile sig_atomic_t g_sig_shutdown = 0;
 static volatile sig_atomic_t g_sig_log_upload = 0;
+static volatile sig_atomic_t g_sig_log_upload_ondemand = 0;
 static volatile sig_atomic_t g_sig_reload = 0;
 
 T2ERROR initTelemetry()
@@ -161,11 +162,21 @@ void sig_handler(int sig, siginfo_t* info, void* uc)
      * The main loop polls these flags and performs the actual work. */
     if ( sig == SIGINT || sig == SIGTERM )
     {
+        if (g_sig_shutdown)
+        {
+            /* Repeated shutdown signal while terminate() is still running.
+             * Force immediate exit.  _exit() is async-signal-safe. */
+            _exit(1);
+        }
         g_sig_shutdown = 1;
     }
-    else if ( sig == SIGUSR1 || sig == LOG_UPLOAD || sig == LOG_UPLOAD_ONDEMAND || sig == SIGIO )
+    else if ( sig == SIGUSR1 || sig == LOG_UPLOAD )
     {
         g_sig_log_upload = 1;
+    }
+    else if ( sig == LOG_UPLOAD_ONDEMAND || sig == SIGIO )
+    {
+        g_sig_log_upload_ondemand = 1;
     }
     else if ( sig == SIGUSR2 || sig == EXEC_RELOAD )
     {
@@ -245,8 +256,14 @@ static void t2DaemonMainModeInit( )
         if(g_sig_log_upload)
         {
             g_sig_log_upload = 0;
-            T2Info("LOG_UPLOAD signal received\n");
+            T2Info("LOG_UPLOAD received!\n");
             set_retainseekmap(false);
+            ReportProfiles_Interrupt();
+        }
+        if(g_sig_log_upload_ondemand)
+        {
+            g_sig_log_upload_ondemand = 0;
+            T2Info("LOG_UPLOAD_ONDEMAND received!\n");
             ReportProfiles_Interrupt();
         }
         if(g_sig_reload)

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -201,6 +201,7 @@ static void t2DaemonMainModeInit( )
     act.sa_sigaction = sig_handler;
     act.sa_flags = SA_ONSTACK | SA_SIGINFO ;
 
+    sigemptyset(&blocking_signal);
     sigaddset(&blocking_signal, SIGUSR2);
     sigaddset(&blocking_signal, SIGUSR1);
     sigaddset(&blocking_signal, LOG_UPLOAD);

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -67,6 +67,12 @@ static bool isDebugEnabled = true;
 static int initcomplete = 0;
 static pid_t DAEMONPID; //static varible store the Main Pid
 
+/* Signal-safe flags: sig_handler sets these; main loop dispatches.
+ * volatile sig_atomic_t is the only type guaranteed safe from signal context. */
+static volatile sig_atomic_t g_sig_shutdown = 0;
+static volatile sig_atomic_t g_sig_log_upload = 0;
+static volatile sig_atomic_t g_sig_reload = 0;
+
 T2ERROR initTelemetry()
 {
     T2ERROR ret = T2ERROR_FAILURE;
@@ -165,82 +171,41 @@ static void _print_stack_backtrace(void)
 
 void sig_handler(int sig, siginfo_t* info, void* uc)
 {
-    if(DAEMONPID == getpid())
-    {
-        int fd;
-        const char *path = "/tmp/telemetry_logupload";
-        if ( sig == SIGINT )
-        {
-            T2Info(("SIGINT received!\n"));
-#ifndef DEVICE_EXTENDER
-            uninitXConfClient();
-#endif
-            ReportProfiles_uninit();
-            exit(0);
-        }
-        else if ( sig == SIGUSR1 || sig == LOG_UPLOAD )
-        {
-            T2Info(("LOG_UPLOAD received!\n"));
-            set_retainseekmap(false);
-            ReportProfiles_Interrupt();
-        }
-        else if (sig == LOG_UPLOAD_ONDEMAND || sig == SIGIO)
-        {
-            T2Info(("LOG_UPLOAD_ONDEMAND received!\n"));
-            ReportProfiles_Interrupt();
-        }
-        else if(sig == SIGUSR2 || sig == EXEC_RELOAD)
-        {
-            T2Info(("EXEC_RELOAD received!\n"));
-            fd = open(path, O_RDONLY | O_CREAT, 0400);
-            if(fd  == -1)
-            {
-                T2Warning("Failed to open the file\n");
-            }
-            else
-            {
-                T2Debug("File is created\n");
-                close(fd);
-            }
-#ifndef DEVICE_EXTENDER
-            stopXConfClient();
-            if(T2ERROR_SUCCESS == startXConfClient())
-            {
-                T2Info("XCONF config reload - SUCCESS \n");
-            }
-            else
-            {
-                T2Info("XCONF config reload - IN PROGRESS ... Ignore current reload request \n");
-            }
-#endif
+    int saved_errno = errno;
+    (void)info;
+    (void)uc;
 
-        }
-        else if ( sig == SIGTERM || sig == SIGKILL )
+    if(DAEMONPID != getpid())
+    {
+        /* Child process: terminate immediately for fatal signals */
+        if(!(sig == SIGUSR1 || sig == LOG_UPLOAD || sig == LOG_UPLOAD_ONDEMAND || sig == SIGIO || sig == SIGCHLD || sig == SIGPIPE || sig == SIGUSR2 || sig == EXEC_RELOAD || sig == SIGALRM ))
         {
-            terminate();
-            exit(0);
+            _exit(1);
         }
-        else
-        {
-            /* get stack trace first */
-            _print_stack_backtrace();
-            terminate();
-            T2Warning("[%s][%u] Signal number: %d\n", __FUNCTION__, __LINE__, info->si_signo);
-            T2Warning("[%s][%u] Signal error: %d\n", __FUNCTION__, __LINE__, info->si_errno);
-            T2Warning("[%s][%u] Signal code: %d\n", __FUNCTION__, __LINE__, info->si_code);
-            T2Warning("[%s][%u] Signal value: %d\n", __FUNCTION__, __LINE__, info->si_value.sival_int);
-            (void)uc;
-            exit(0);
-        }
+        errno = saved_errno;
+        return;
+    }
+
+    /* POSIX async-signal-safe: only set flags here.
+     * The main loop polls these flags and performs the actual work. */
+    if ( sig == SIGINT || sig == SIGTERM || sig == SIGKILL )
+    {
+        g_sig_shutdown = 1;
+    }
+    else if ( sig == SIGUSR1 || sig == LOG_UPLOAD || sig == LOG_UPLOAD_ONDEMAND || sig == SIGIO )
+    {
+        g_sig_log_upload = 1;
+    }
+    else if ( sig == SIGUSR2 || sig == EXEC_RELOAD )
+    {
+        g_sig_reload = 1;
     }
     else
     {
-        // This logic is added to terminate child imediately if we get terminate signals eg:SIGTERM / SIGKILL ...
-        if(!(sig == SIGUSR1 || sig == LOG_UPLOAD || sig == LOG_UPLOAD_ONDEMAND || sig == SIGIO || sig == SIGCHLD || sig == SIGPIPE || sig == SIGUSR2 || sig == EXEC_RELOAD || sig == SIGALRM ))
-        {
-            exit(0);
-        }
+        /* Unknown fatal signal — request shutdown */
+        g_sig_shutdown = 1;
     }
+    errno = saved_errno;
 }
 
 static void t2DaemonMainModeInit( )
@@ -277,6 +242,7 @@ static void t2DaemonMainModeInit( )
     DAEMONPID = getpid(); // save the pid of the deamon
     T2Debug("Telemetry 2.0 Process PID %d\n", (int)DAEMONPID); //Debug line
 
+    sigaction(SIGINT, &act, NULL);
     sigaction(SIGTERM, &act, NULL);
     sigaction(SIGUSR1, &act, NULL);
     sigaction(LOG_UPLOAD, &act, NULL);
@@ -293,9 +259,55 @@ static void t2DaemonMainModeInit( )
 
     T2Info("Telemetry 2.0 Component Init Success\n");
 
+    /* Main dispatch loop: poll signal flags set by sig_handler.
+     * All signal-unsafe work (uninit, logging, mutex ops) happens here
+     * in normal thread context, not in signal handler context. */
     while(1)
     {
-        sleep(30);
+        if(g_sig_shutdown)
+        {
+            T2Info("Shutdown signal received, terminating\n");
+            terminate();
+            exit(0);
+        }
+        if(g_sig_log_upload)
+        {
+            g_sig_log_upload = 0;
+            T2Info("LOG_UPLOAD signal received\n");
+            set_retainseekmap(false);
+            ReportProfiles_Interrupt();
+        }
+        if(g_sig_reload)
+        {
+            g_sig_reload = 0;
+            T2Info("EXEC_RELOAD signal received\n");
+            {
+                int fd;
+                const char *path = "/tmp/telemetry_logupload";
+                fd = open(path, O_RDONLY | O_CREAT, 0400);
+                if(fd == -1)
+                {
+                    T2Warning("Failed to open the file\n");
+                }
+                else
+                {
+                    T2Debug("File is created\n");
+                    close(fd);
+                }
+            }
+#ifndef DEVICE_EXTENDER
+            stopXConfClient();
+            if(T2ERROR_SUCCESS == startXConfClient())
+            {
+                T2Info("XCONF config reload - SUCCESS \n");
+            }
+            else
+            {
+                T2Info("XCONF config reload - IN PROGRESS ... Ignore current reload request \n");
+            }
+#endif
+        }
+        sleep(1);
     }
     T2Info("Telemetry 2.0 Process Terminated\n");
 }

--- a/source/xconf-client/xconfclient.c
+++ b/source/xconf-client/xconfclient.c
@@ -1099,14 +1099,18 @@ void uninitXConfClient()
         pthread_cond_signal(&xcThreadCond);
         pthread_mutex_unlock(&xcThreadMutex);
         pthread_join(xcrThread, NULL);
-        pthread_mutex_destroy(&xcMutex);
-        pthread_mutex_destroy(&xcThreadMutex);
-        pthread_cond_destroy(&xcCond);
-        pthread_cond_destroy(&xcThreadCond);
 #ifdef DCMAGENT
         bexitDCMThread = false;
         pthread_join(dcmThread, NULL);
 #endif
+        /* Destroy synchronization primitives only after ALL threads using
+         * them have been joined.  Previously these were destroyed between
+         * the xcrThread join and dcmThread join, creating a window where
+         * the exiting thread could still reference destroyed mutexes. */
+        pthread_mutex_destroy(&xcMutex);
+        pthread_mutex_destroy(&xcThreadMutex);
+        pthread_cond_destroy(&xcCond);
+        pthread_cond_destroy(&xcThreadCond);
     }
     else
     {


### PR DESCRIPTION
Reason for change: Fix the following TSAN issues -


1: Data Races (profile.c, t2collection.c, rbusmethodinterface.c)
2: Lock Order / Deadlock (profile.c)
3: Mutex Misuse (profile.c, rbusmethodinterface.c, xconfclient.c)
4: Signal Safety and crash (multiple files)
Test Procedure: Build RDKE image

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)