### PR TITLE
RDKB-64847: Serialize telemetry report execution across Xconf and multi-profile paths

### DIFF
--- a/source/bulkdata/profile.c
+++ b/source/bulkdata/profile.c
@@ -395,6 +395,7 @@ static void* CollectAndReport(void* data)
         struct timespec elapsedTime;
         char* customLogPath = NULL;
         int clockReturn = 0;
+        bool executionGateAcquired = false;
 
         T2ERROR ret = T2ERROR_FAILURE;
         if( profile->name == NULL || profile->encodingType == NULL || profile->protocol == NULL )
@@ -420,6 +421,8 @@ static void* CollectAndReport(void* data)
             goto reportThreadEnd;
         }
 
+        ReportProfiles_Lock(profile->name);
+        executionGateAcquired = true;
         T2Info("%s ++in profileName : %s\n", __FUNCTION__, profile->name);
 
 
@@ -896,6 +899,11 @@ static void* CollectAndReport(void* data)
             T2Debug(" profile->triggerReportOnCondition is not set \n");
         }
 reportThreadEnd :
+    if(executionGateAcquired)
+    {
+        ReportProfiles_Unlock();
+        executionGateAcquired = false;
+    }
         T2Info("%s while Loop -- END; wait for restart event\n", __FUNCTION__);
         T2Info("%s --out\n", __FUNCTION__);
         pthread_mutex_lock(&profile->reuseThreadMutex);

--- a/source/bulkdata/profilexconf.c
+++ b/source/bulkdata/profilexconf.c
@@ -222,6 +222,8 @@ static void* CollectAndReportXconf(void* data)
 
     do
     {
+        bool executionGateAcquired = false;
+
         /* CRITICAL SECTION START: Acquire xconfProfileLock to check/access singleProfile */
         pthread_mutex_lock(&xconfProfileLock);
 
@@ -277,6 +279,9 @@ static void* CollectAndReportXconf(void* data)
          */
         pthread_mutex_unlock(&xconfProfileLock);
         /* CRITICAL SECTION END - xconfProfileLock released, other threads can now proceed */
+
+        ReportProfiles_Lock(profile->name);
+        executionGateAcquired = true;
 
         int clockReturn = 0;
         clockReturn = clock_gettime(CLOCK_MONOTONIC, &startTime);
@@ -570,6 +575,11 @@ static void* CollectAndReportXconf(void* data)
             profile->reportInProgress = false;
         }
 reportXconfThreadEnd :
+        if(executionGateAcquired)
+        {
+            ReportProfiles_Unlock();
+            executionGateAcquired = false;
+        }
         T2Info("%s while Loop -- END \n", __FUNCTION__);
         /* CRITICAL: Check wait condition in a loop to handle spurious wakeups.
          * pthread_cond_wait can wake up spuriously without an actual signal. We must verify the actual

--- a/source/bulkdata/reportprofiles.c
+++ b/source/bulkdata/reportprofiles.c
@@ -91,6 +91,10 @@ static cap_user appcaps;
 static BulkData bulkdata;
 static bool rpInitialized = false;
 static char *t2Version = NULL;
+static pthread_mutex_t reportExecutionGateMutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t reportExecutionGateCond = PTHREAD_COND_INITIALIZER;
+static bool reportExecutionGateBusy = false;
+static char reportExecutionGateOwner[256] = { 0 };
 
 pthread_mutex_t rpMutex = PTHREAD_MUTEX_INITIALIZER;
 T2ERROR RemovePreRPfromDisk(const char* path, hash_map_t *map);
@@ -213,6 +217,44 @@ void ReportProfiles_Interrupt()
     }
 
     T2Debug("%s --out\n", __FUNCTION__);
+}
+
+void ReportProfiles_Lock(const char* profileName)
+{
+    const char* currentProfile = (profileName && profileName[0] != '\0') ? profileName : "UNKNOWN";
+    bool waitLogged = false;
+
+    pthread_mutex_lock(&reportExecutionGateMutex);
+    while(reportExecutionGateBusy)
+    {
+        if(!waitLogged)
+        {
+            T2Info("Report execution gate busy. profile=%s waiting for active profile=%s\n",
+                   currentProfile,
+                   reportExecutionGateOwner[0] != '\0' ? reportExecutionGateOwner : "UNKNOWN");
+            waitLogged = true;
+        }
+        pthread_cond_wait(&reportExecutionGateCond, &reportExecutionGateMutex);
+    }
+
+    reportExecutionGateBusy = true;
+    snprintf(reportExecutionGateOwner, sizeof(reportExecutionGateOwner), "%s", currentProfile);
+    T2Info("Report execution gate acquired for profile=%s\n", reportExecutionGateOwner);
+    pthread_mutex_unlock(&reportExecutionGateMutex);
+}
+
+void ReportProfiles_Unlock(void)
+{
+    pthread_mutex_lock(&reportExecutionGateMutex);
+    if(reportExecutionGateBusy)
+    {
+        T2Info("Report execution gate released for profile=%s\n",
+               reportExecutionGateOwner[0] != '\0' ? reportExecutionGateOwner : "UNKNOWN");
+        reportExecutionGateBusy = false;
+        reportExecutionGateOwner[0] = '\0';
+        pthread_cond_broadcast(&reportExecutionGateCond);
+    }
+    pthread_mutex_unlock(&reportExecutionGateMutex);
 }
 
 void ReportProfiles_TimeoutCb(char* profileName, bool isClearSeekMap)

--- a/source/bulkdata/reportprofiles.c
+++ b/source/bulkdata/reportprofiles.c
@@ -94,7 +94,7 @@ static char *t2Version = NULL;
 static pthread_mutex_t reportExecutionGateMutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t reportExecutionGateCond = PTHREAD_COND_INITIALIZER;
 static bool reportExecutionGateBusy = false;
-static char reportExecutionGateOwner[256] = { 0 };
+static char reportExecutionGateOwner[MAX_PROFILENAMES_LENGTH] = { 0 };
 
 pthread_mutex_t rpMutex = PTHREAD_MUTEX_INITIALIZER;
 T2ERROR RemovePreRPfromDisk(const char* path, hash_map_t *map);

--- a/source/bulkdata/reportprofiles.c
+++ b/source/bulkdata/reportprofiles.c
@@ -252,7 +252,7 @@ void ReportProfiles_Unlock(void)
                reportExecutionGateOwner[0] != '\0' ? reportExecutionGateOwner : "UNKNOWN");
         reportExecutionGateBusy = false;
         reportExecutionGateOwner[0] = '\0';
-        pthread_cond_broadcast(&reportExecutionGateCond);
+        pthread_cond_signal(&reportExecutionGateCond);
     }
     pthread_mutex_unlock(&reportExecutionGateMutex);
 }

--- a/source/bulkdata/reportprofiles.h
+++ b/source/bulkdata/reportprofiles.h
@@ -91,6 +91,10 @@ void ReportProfiles_ProcessReportProfilesBlob(cJSON *profiles_root, bool rprofil
 
 void ReportProfiles_Interrupt();
 
+void ReportProfiles_Lock(const char* profileName);
+
+void ReportProfiles_Unlock(void);
+
 void generateDcaReport(bool isDelayed, bool isOnDemand);
 
 /* MSGPACK Declarations */


### PR DESCRIPTION
**Reason for change**: Introduce a global report execution lock to enforce a single active report generation path across Xconf and non-Xconf flows, add lock ownership/wait logging for runtime observability, and reduce timing contention and CPU spikes caused by parallel profile report generation.
**Test Procedure:** performance testing
**Risks**: Medium
**Priority**: P0
**Signed-off-by:** Thamim Razith Abbas Ali <tabbas651@comcast.com>