### PR TITLE
RDKB-64847: Observed spike in load and CPU due to cpu_telemetry2_0

### DIFF
--- a/source/bulkdata/profile.c
+++ b/source/bulkdata/profile.c
@@ -49,6 +49,7 @@
 
 #ifdef GTEST_ENABLE
 #define sendReportOverHTTP __wrap_sendReportOverHTTP
+#define sendReportOverHTTPWithSmartDelay __wrap_sendReportOverHTTPWithSmartDelay
 #define sendCachedReportsOverHTTP __wrap_sendCachedReportsOverHTTP
 #endif
 
@@ -512,6 +513,7 @@ static void* CollectAndReport(void* data)
                 {
                     processTopPattern(profile->name, profile->topMarkerList, 0);
                     encodeTopResultInJSON(valArray, profile->topMarkerList);
+                    setTopPatternExecuted(true);
                 }
                 if(profile->gMarkerList != NULL && Vector_Size(profile->gMarkerList) > 0)
                 {
@@ -645,7 +647,7 @@ static void* CollectAndReport(void* data)
                             if(n == ETIMEDOUT)
                             {
                                 T2Info("TIMEOUT for maxUploadLatency of profile %s\n", profile->name);
-                                ret = sendReportOverHTTP(httpUrl, jsonReport);
+                                ret = sendReportOverHTTPWithSmartDelay(httpUrl, jsonReport);
                             }
                             else if(n == 0)
                             {
@@ -692,7 +694,7 @@ static void* CollectAndReport(void* data)
                         }
                         else
                         {
-                            ret = sendReportOverHTTP(httpUrl, jsonReport);
+                            ret = sendReportOverHTTPWithSmartDelay(httpUrl, jsonReport);
                         }
                     }
                     else

--- a/source/bulkdata/profilexconf.c
+++ b/source/bulkdata/profilexconf.c
@@ -59,6 +59,7 @@ static bool isOnDemandReport = false ;
 
 #ifdef GTEST_ENABLE
 #define sendReportOverHTTP __wrap_sendReportOverHTTP
+#define sendReportOverHTTPWithSmartDelay __wrap_sendReportOverHTTPWithSmartDelay
 #define sendCachedReportsOverHTTP __wrap_sendCachedReportsOverHTTP
 #endif
 
@@ -324,6 +325,7 @@ static void* CollectAndReportXconf(void* data)
             if(profile->topMarkerList != NULL && Vector_Size(profile->topMarkerList) > 0)
             {
                 processTopPattern(profile->name, profile->topMarkerList, count);
+                setTopPatternExecuted(true);
                 T2Info("Top markers report is completed\n");
                 encodeTopResultInJSON(valArray, profile->topMarkerList);
             }
@@ -445,7 +447,8 @@ static void* CollectAndReportXconf(void* data)
                 else
                 {
                     T2Debug("Abort upload is not yet set.\n");
-                    ret = sendReportOverHTTP(profile->t2HTTPDest->URL, jsonReport);
+                    ret = sendReportOverHTTPWithSmartDelay(profile->t2HTTPDest->URL, jsonReport);
+
                 }
 
 #ifdef PERSIST_LOG_MON_REF

--- a/source/protocol/http/curlinterface.c
+++ b/source/protocol/http/curlinterface.c
@@ -70,6 +70,26 @@ typedef enum _ADDRESS_TYPE
     ADDR_IPV6
 } ADDRESS_TYPE;
 
+#define T2_POST_TOP_SMART_DELAY_SEC  2
+static bool g_topPatternExecuted = false;
+
+void setTopPatternExecuted(bool executed)
+{
+    g_topPatternExecuted = executed;
+}
+
+T2ERROR sendReportOverHTTPWithSmartDelay(char* httpUrl, char* payload)
+{
+    if(g_topPatternExecuted)
+    {
+        T2Info("Smart delay: %d sec after top-pattern before HTTP upload\n",
+               T2_POST_TOP_SMART_DELAY_SEC);
+        sleep(T2_POST_TOP_SMART_DELAY_SEC);
+        g_topPatternExecuted = false;
+    }
+    return sendReportOverHTTP(httpUrl, payload);
+}
+
 T2ERROR sendReportOverHTTP(char *httpUrl, char *payload)
 {
     T2ERROR ret = T2ERROR_FAILURE;

--- a/source/protocol/http/curlinterface.h
+++ b/source/protocol/http/curlinterface.h
@@ -37,6 +37,9 @@
 
 T2ERROR sendReportOverHTTP(char *httpUrl, char* payload);
 
+void setTopPatternExecuted(bool executed);
+T2ERROR sendReportOverHTTPWithSmartDelay(char* httpUrl, char* payload);
+
 T2ERROR sendCachedReportsOverHTTP(char *httpUrl, Vector *reportList);
 
 #ifdef LIBRDKCERTSEL_BUILD


### PR DESCRIPTION
Reason for change: When top-pattern (processTopPattern) completes, system resources remain briefly contended. If HTTP upload fires immediately after, curl hits WAN interface timeouts or FD exhaustion on resource-constrained devices. Added a 2-second smart delay wrapper (sendReportOverHTTPWithSmartDelay) that pauses only when top-pattern has just executed, giving the system time to release contested resources before upload. Test Procedure: performance testing
Risks: Medium
Priority: P0