### PR TITLE
RDKCOM-5614: RDKBDEV-3443 Add typed fields support for telemetry reporting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,20 @@ AC_ARG_ENABLE([libsyswrapper],
 AM_CONDITIONAL([IS_LIBSYSWRAPPER_ENABLED], [test x$IS_LIBSYSWRAPPER_ENABLED = xtrue])
 AC_SUBST(LIBSYSWRAPPER_FLAG)
 
+ENABLE_SUPPORT_TYPING_FIELDS=false
+AC_ARG_ENABLE([support-typing-fields],
+              AS_HELP_STRING([--enable-support-typing-fields],[enable SUPPORT_TYPING_FIELDS (default is no)]),
+              [
+                case "${enableval}" in
+                 yes) ENABLE_SUPPORT_TYPING_FIELDS=true;;
+                  no) AC_MSG_ERROR([SUPPORT_TYPING_FIELDS is disabled]) ;;
+                   *) AC_MSG_ERROR([bad value ${enableval} for --enable-support-typing-fields]) ;;
+                esac
+              ],
+              [echo "SUPPORT_TYPING_FIELDS is disabled"])
+
+AM_CONDITIONAL([ENABLE_SUPPORT_TYPING_FIELDS], [test x$ENABLE_SUPPORT_TYPING_FIELDS = xtrue])
+
 #privacy control flag
 IS_PRIVACYCONTROL_ENABLED=false
 AC_ARG_ENABLE([privacycontrol],

--- a/source/ccspinterface/Makefile.am
+++ b/source/ccspinterface/Makefile.am
@@ -47,3 +47,7 @@ libccspinterface_la_CPPFLAGS +=  -I${top_srcdir}/source/privacycontrol
 libccspinterface_la_DEPENDENCIES = ${top_builddir}/source/privacycontrol/libt2thunder_privacycontrol.la
 libccspinterface_la_LIBADD = ${top_builddir}/source/privacycontrol/libt2thunder_privacycontrol.la
 endif
+
+if ENABLE_SUPPORT_TYPING_FIELDS
+libccspinterface_la_CPPFLAGS += -DSUPPORT_TYPING_FIELDS
+endif

--- a/source/ccspinterface/busInterface.h
+++ b/source/ccspinterface/busInterface.h
@@ -28,10 +28,30 @@
 #define CCSP_COMPONENT_ID          "eRT.com.cisco.spvtg.ccsp.telemetry"
 #endif // CCSP_SUPPORT_ENABLED 
 
+#ifdef SUPPORT_TYPING_FIELDS
+typedef enum
+{
+    TR181_TYPE_STRING,
+    TR181_TYPE_INT,
+    TR181_TYPE_UNSIGNED,
+    TR181_TYPE_BOOLEAN,
+    TR181_TYPE_DATETIME,
+    TR181_TYPE_BASE64,
+    TR181_TYPE_LONG,
+    TR181_TYPE_UNSIGNED_LONG,
+    TR181_TYPE_FLOAT,
+    TR181_TYPE_DOUBLE
+} TR181ParameterType;
+#endif
+
 typedef struct
 {
     char *parameterName;
     char *parameterValue;
+
+#ifdef SUPPORT_TYPING_FIELDS
+    TR181ParameterType type;
+#endif
 
 } tr181ValStruct_t;
 

--- a/source/ccspinterface/ccspinterface.c
+++ b/source/ccspinterface/ccspinterface.c
@@ -198,6 +198,36 @@ static void freeCCSPParamValueSt(parameterValStruct_t **valStructs, int valSize)
     free_parameterValStruct_t(bus_handle, valSize, valStructs);
 }
 
+#ifdef SUPPORT_TYPING_FIELDS
+static TR181ParameterType getTR181TypeFromCCSP(int ccspType)
+{
+    switch(ccspType)
+    {
+    case ccsp_boolean:
+        return TR181_TYPE_BOOLEAN;
+    case ccsp_int:
+        return TR181_TYPE_INT;
+    case ccsp_unsignedInt:
+        return TR181_TYPE_UNSIGNED;
+    case ccsp_long:
+        return TR181_TYPE_LONG;
+    case ccsp_unsignedLong:
+        return TR181_TYPE_UNSIGNED_LONG;
+    case ccsp_float:
+        return TR181_TYPE_FLOAT;
+    case ccsp_double:
+        return TR181_TYPE_DOUBLE;
+    case ccsp_dateTime:
+        return TR181_TYPE_DATETIME;
+    case ccsp_base64:
+        return TR181_TYPE_BASE64;
+    case ccsp_string:
+    default:
+        return TR181_TYPE_STRING;
+    }
+}
+#endif
+
 T2ERROR getCCSPParamVal(const char* paramName, char **paramValue)
 {
     T2Debug("%s ++in \n", __FUNCTION__);
@@ -306,6 +336,9 @@ Vector* getCCSPProfileParamValues(Vector *paramList, int execount)
                 {
                     paramValues[0]->parameterName = strdup(paramNames[0]);
                     paramValues[0]->parameterValue = strdup("NULL");
+#ifdef SUPPORT_TYPING_FIELDS
+                    paramValues[0]->type = TR181_TYPE_STRING;
+#endif
                 }
             }
         }
@@ -323,6 +356,9 @@ Vector* getCCSPProfileParamValues(Vector *paramList, int execount)
                         {
                             paramValues[iterate]->parameterName = strdup((ccspParamValues[iterate])->parameterName);
                             paramValues[iterate]->parameterValue = strdup((ccspParamValues[iterate])->parameterValue);
+#ifdef SUPPORT_TYPING_FIELDS
+                            paramValues[iterate]->type = getTR181TypeFromCCSP((ccspParamValues[iterate])->type);
+#endif
                         }
                     }
                 }

--- a/source/ccspinterface/rbusInterface.c
+++ b/source/ccspinterface/rbusInterface.c
@@ -142,6 +142,40 @@ static void rBusInterface_Uninit( )
     rbus_close(t2bus_handle);
 }
 
+#ifdef SUPPORT_TYPING_FIELDS
+static TR181ParameterType getTR181TypeFromRbus(rbusValueType_t rbusValueType)
+{
+    switch(rbusValueType)
+    {
+    case RBUS_INT32:
+    case RBUS_INT16:
+    case RBUS_INT8:
+        return TR181_TYPE_INT;
+    case RBUS_UINT32:
+    case RBUS_UINT16:
+    case RBUS_UINT8:
+        return TR181_TYPE_UNSIGNED;
+    case RBUS_INT64:
+        return TR181_TYPE_LONG;
+    case RBUS_UINT64:
+        return TR181_TYPE_UNSIGNED_LONG;
+    case RBUS_BOOLEAN:
+        return TR181_TYPE_BOOLEAN;
+    case RBUS_SINGLE:
+        return TR181_TYPE_FLOAT;
+    case RBUS_DOUBLE:
+        return TR181_TYPE_DOUBLE;
+    case RBUS_DATETIME:
+        return TR181_TYPE_DATETIME;
+    case RBUS_BYTES:
+        return TR181_TYPE_BASE64;
+    case RBUS_STRING:
+    default:
+        return TR181_TYPE_STRING;
+    }
+}
+#endif
+
 T2ERROR getRbusParameterVal(const char* paramName, char **paramValue)
 {
     T2Debug("%s ++in \n", __FUNCTION__);
@@ -284,6 +318,9 @@ Vector* getRbusProfileParamValues(Vector *paramList, int execcount)
                 paramValues[0] = (tr181ValStruct_t*) malloc(sizeof(tr181ValStruct_t));
                 paramValues[0]->parameterName = (param != NULL) ? strdup(param) : strdup("UNKNOWN");
                 paramValues[0]->parameterValue = strdup("NULL");
+#ifdef SUPPORT_TYPING_FIELDS
+                paramValues[0]->type = TR181_TYPE_STRING;
+#endif
                 // If parameter doesn't exist in device we do populate with entry as NULL.
                 // So count of populated data list has 1 entry and is not 0
                 profVals->paramValueCount = 1;
@@ -327,6 +364,9 @@ Vector* getRbusProfileParamValues(Vector *paramList, int execcount)
                             {
                                 paramValues[iterate]->parameterValue = rbusValue_ToString(value, NULL, 0);
                             }
+#ifdef SUPPORT_TYPING_FIELDS
+                            paramValues[iterate]->type = getTR181TypeFromRbus(rbusValueType);
+#endif
 
 #if defined(ENABLE_RDKV_SUPPORT)
                             // Workaround as video platforms doesn't have a TR param which gives Firmware name

--- a/source/reportgen/Makefile.am
+++ b/source/reportgen/Makefile.am
@@ -30,3 +30,7 @@ libreportgen_la_CPPFLAGS = -fPIC -I${PKG_CONFIG_SYSROOT_DIR}$(includedir)/dbus-1
                                 -I${top_srcdir}/source/bulkdata \
                                 -I${top_srcdir}/source/utils \
                                 -I${top_srcdir}/source/dcautil
+
+if ENABLE_SUPPORT_TYPING_FIELDS
+libreportgen_la_CPPFLAGS += -DSUPPORT_TYPING_FIELDS
+endif

--- a/source/reportgen/reportgen.c
+++ b/source/reportgen/reportgen.c
@@ -29,6 +29,9 @@
 #include "t2common.h"
 #include "dcautil.h"
 #include "busInterface.h"
+#ifdef SUPPORT_TYPING_FIELDS
+#include <strings.h>
+#endif
 
 static bool checkForEmptyString( char* valueString )
 {
@@ -152,6 +155,52 @@ void trimLeadingAndTrailingws(char* string)
     T2Debug("%s --Out \n", __FUNCTION__);
 
 }
+
+#ifdef SUPPORT_TYPING_FIELDS
+static cJSON* addTypedParamValueToObject(cJSON *object, const char *name, tr181ValStruct_t *paramValue)
+{
+    if(object == NULL || name == NULL || paramValue == NULL)
+    {
+        return NULL;
+    }
+
+    switch(paramValue->type)
+    {
+    case TR181_TYPE_BOOLEAN:
+    {
+        bool boolValue = false;
+        if(paramValue->parameterValue &&
+                (strcasecmp(paramValue->parameterValue, "true") == 0 ||
+                 strcmp(paramValue->parameterValue, "1") == 0))
+        {
+            boolValue = true;
+        }
+        return cJSON_AddBoolToObject(object, name, boolValue);
+    }
+
+    case TR181_TYPE_INT:
+    case TR181_TYPE_LONG:
+        return cJSON_AddNumberToObject(object, name,
+                                       (double)strtoll(paramValue->parameterValue ? paramValue->parameterValue : "0", NULL, 10));
+
+    case TR181_TYPE_UNSIGNED:
+    case TR181_TYPE_UNSIGNED_LONG:
+        return cJSON_AddNumberToObject(object, name,
+                                       (double)strtoull(paramValue->parameterValue ? paramValue->parameterValue : "0", NULL, 10));
+
+    case TR181_TYPE_FLOAT:
+    case TR181_TYPE_DOUBLE:
+        return cJSON_AddNumberToObject(object, name,
+                                       strtod(paramValue->parameterValue ? paramValue->parameterValue : "0", NULL));
+
+    case TR181_TYPE_STRING:
+    case TR181_TYPE_DATETIME:
+    case TR181_TYPE_BASE64:
+    default:
+        return cJSON_AddStringToObject(object, name, paramValue->parameterValue ? paramValue->parameterValue : "");
+    }
+}
+#endif
 
 /**
  * @brief Apply regex pattern to a string value and update it in place
@@ -380,12 +429,23 @@ T2ERROR encodeParamResultInJSON(cJSON *valArray, Vector *paramNameList, Vector *
                     return T2ERROR_FAILURE;
                 }
                 T2Info("Paramter was not successfully retrieved... \n");
+#ifdef SUPPORT_TYPING_FIELDS
+                cJSON *nullItem = cJSON_CreateNull();
+                if(nullItem == NULL)
+                {
+                    T2Error("cJSON_CreateNull failed.\n");
+                    cJSON_Delete(arrayItem);
+                    return T2ERROR_FAILURE;
+                }
+                cJSON_AddItemToObject(arrayItem, param->name, nullItem);
+#else
                 if(cJSON_AddStringToObject(arrayItem, param->name, "NULL")  == NULL)
                 {
                     T2Error("cJSON_AddStringToObject failed.\n");
                     cJSON_Delete(arrayItem);
                     return T2ERROR_FAILURE;
                 }
+#endif
                 cJSON_AddItemToArray(valArray, arrayItem);
             }
             else
@@ -442,12 +502,21 @@ T2ERROR encodeParamResultInJSON(cJSON *valArray, Vector *paramNameList, Vector *
                         }
                     }
 
+#ifdef SUPPORT_TYPING_FIELDS
+                    if(addTypedParamValueToObject(arrayItem, param->name, paramValues[0]) == NULL)
+                    {
+                        T2Error("addTypedParamValueToObject failed.\n");
+                        cJSON_Delete(arrayItem);
+                        return T2ERROR_FAILURE;
+                    }
+#else
                     if(cJSON_AddStringToObject(arrayItem, param->name, paramValues[0]->parameterValue)  == NULL)
                     {
                         T2Error("cJSON_AddStringToObject failed.\n");
                         cJSON_Delete(arrayItem);
                         return T2ERROR_FAILURE;
                     }
+#endif
                     cJSON_AddItemToArray(valArray, arrayItem);
                 }
             }
@@ -556,9 +625,15 @@ T2ERROR encodeParamResultInJSON(cJSON *valArray, Vector *paramNameList, Vector *
                                 if (nextToken == NULL)
                                 {
                                     // Adding final parameter
+#ifdef SUPPORT_TYPING_FIELDS
+                                    if (addTypedParamValueToObject(currentObject, token, paramValues[valIndex]) == NULL)
+                                    {
+                                        T2Error("addTypedParamValueToObject failed.\n");
+#else
                                     if (cJSON_AddStringToObject(currentObject, token, paramValues[valIndex]->parameterValue) == NULL)
                                     {
                                         T2Error("cJSON_AddStringToObject failed.\n");
+#endif
                                         if (parameterName)
                                         {
                                             free(parameterName);
@@ -773,9 +848,15 @@ T2ERROR encodeParamResultInJSON(cJSON *valArray, Vector *paramNameList, Vector *
                                 }
                             }
 
+#ifdef SUPPORT_TYPING_FIELDS
+                            if (addTypedParamValueToObject(valItem, paramValues[valIndex]->parameterName, paramValues[valIndex]) == NULL)
+                            {
+                                T2Error("addTypedParamValueToObject failed.\n");
+#else
                             if (cJSON_AddStringToObject(valItem, paramValues[valIndex]->parameterName, paramValues[valIndex]->parameterValue) == NULL)
                             {
                                 T2Error("cJSON_AddStringToObject failed\n");
+#endif
                                 cJSON_Delete(arrayItem);
                                 cJSON_Delete(valItem);
                                 return T2ERROR_FAILURE;

--- a/source/reportgen/reportgen.c
+++ b/source/reportgen/reportgen.c
@@ -428,7 +428,7 @@ T2ERROR encodeParamResultInJSON(cJSON *valArray, Vector *paramNameList, Vector *
                     T2Error("cJSON_CreateObject failed.. arrayItem is NULL \n");
                     return T2ERROR_FAILURE;
                 }
-                T2Info("Paramter was not successfully retrieved... \n");
+                T2Info("Parameter was not successfully retrieved... \n");
 #ifdef SUPPORT_TYPING_FIELDS
                 cJSON *nullItem = cJSON_CreateNull();
                 if(nullItem == NULL)


### PR DESCRIPTION
**Reason for change:**

Telemetry currently serializes TR-181 parameter values as strings, regardless of their native data type.

This change adds compile-time support for preserving native TR-181 data types when encoding Telemetry JSON reports. The feature is controlled by the `SUPPORT_TYPING_FIELDS` compile-time flag.

When the feature is enabled:

* Boolean values are encoded as native JSON booleans.
* Integer and other numeric values are encoded as native JSON numbers.
* Textual values continue to be encoded as JSON strings.

When the feature is not enabled, the existing string serialization behavior is preserved.

**Test Procedure:**

1. Build Telemetry with `SUPPORT_TYPING_FIELDS` enabled.
2. Configure a Telemetry profile containing native TR-181 integer and boolean parameters.
3. Generate a Telemetry report and verify that:

   * Integer values are encoded as JSON numbers.
   * Boolean values are encoded as JSON booleans.
4. Build Telemetry without `SUPPORT_TYPING_FIELDS`.
5. Generate the same Telemetry report and verify that integer and boolean values are encoded as strings, preserving the existing behavior.
6. Rebuild Telemetry with `SUPPORT_TYPING_FIELDS` enabled and verify that native JSON serialization is restored.
7. Run the Telemetry unit tests.
8. Run the Telemetry L2 functional tests.
9. Run AStyle and verify that `git diff --check` reports no formatting errors.

**Validation Results:**

* Build with `SUPPORT_TYPING_FIELDS` enabled: PASS
* Build without `SUPPORT_TYPING_FIELDS`: PASS
* Enabled → disabled → enabled build validation: PASS
* Runtime validation with the flag enabled: PASS

  * Integer value encoded as a JSON number.
  * Boolean value encoded as a JSON boolean.
* Runtime validation without the flag: PASS

  * Existing string serialization behavior preserved.
* AStyle formatting: PASS
* `git diff --check`: PASS
* L2 functional tests: PASS

  * Daemon execution tests: PASS
  * Boot sequence tests: PASS
  * XConf communication tests: PASS
  * Multi-profile MessagePack tests: PASS
  * Final result: `All tests passed successfully.`
* Unit tests:

  * Feature-related tests passed.
  * One unrelated pre-existing failure was observed:
    `GETPROCINFO.PMINFO_NULL`
  * The same failure was reproduced on the unmodified `origin/develop` branch.

**Risks:**

Low.

The new behavior is protected by the `SUPPORT_TYPING_FIELDS` compile-time flag. When the flag is not enabled, the existing Telemetry serialization behavior remains unchanged.


Signed-off-by: Abdelkarim El Hosni abdelkarim.elhosni@sfr.com