### PR TITLE
RDKC-16495: telemetry(DCMAGENT) async-subscribe to DCM Reloadconfig T2 - DCM

### DIFF
--- a/source/ccspinterface/rbusInterface.c
+++ b/source/ccspinterface/rbusInterface.c
@@ -1120,6 +1120,34 @@ int getRbusDCMEventStatus()
     return dcmEventStatus;
 }
 
+/*
+ * Async subscription-response handler for the DCM reload config event.
+ * With rbusEvent_SubscribeAsync the subscription is retried in the background
+ * until dcmd (the reload event provider) registers the element, so this callback
+ * only reports the eventual outcome. It does NOT gate dcmEventStatus, which is
+ * set when the reload event itself is received (see rbusReloadConf).
+ */
+static void rbusDCMReloadSubscribeHandler(rbusHandle_t handle,
+        rbusEventSubscription_t* subscription,
+        rbusError_t error)
+{
+    (void) handle; //To avoid compiler Warning
+    if(subscription == NULL)
+    {
+        T2Error("Reload subscribe response has null subscription\n");
+        return;
+    }
+
+    if(error != RBUS_ERROR_SUCCESS)
+    {
+        T2Error("Async subscribe for %s failed. Error code : %d\n", subscription->eventName, error);
+    }
+    else
+    {
+        T2Info("Async subscribe for %s succeeded\n", subscription->eventName);
+    }
+}
+
 T2ERROR registerRbusDCMEventListener()
 {
     T2Debug("%s ++in\n", __FUNCTION__);
@@ -1149,12 +1177,21 @@ T2ERROR registerRbusDCMEventListener()
     }
 
     T2Debug("Subscribing to %s\n", T2_DCM_RELOAD_EVENT);
-    /* Subscribe for reload config event */
-    ret = rbusEvent_Subscribe(t2bus_handle,
-                              T2_DCM_RELOAD_EVENT,
-                              rbusReloadConf,
-                              NULL,
-                              0);
+    /*
+     * Subscribe for the reload config event using the ASYNC variant so the
+     * subscription is retried in the background until dcmd (the reload event
+     * provider) is up. On RDK-C (sysvinit) dcmd can start after telemetry, so a
+     * one-shot synchronous rbusEvent_Subscribe would fail permanently with
+     * "no provider" (err 20) and the DCM<->T2 handshake would never complete.
+     * timeout 0 keeps retrying until the provider appears (mirrors dcmd's own
+     * SubscribeAsync usage for Device.DCM.Setconfig/Processconfig).
+     */
+    ret = rbusEvent_SubscribeAsync(t2bus_handle,
+                                   T2_DCM_RELOAD_EVENT,
+                                   rbusReloadConf,
+                                   rbusDCMReloadSubscribeHandler,
+                                   NULL,
+                                   0);
     if(ret != RBUS_ERROR_SUCCESS)
     {
         T2Error("Failed to subscribe DCM reload event with rbus. Error code : %d\n", ret);


### PR DESCRIPTION
On RDK-C (sysvinit), telemetry2_0 starts well before dcmd, so telemetry's one-shot synchronous rbusEvent_Subscribe(T2_DCM_RELOAD_EVENT) to dcmd's reload provider fails permanently with "no provider" (err 20) and never retries → dcmEventStatus stays 0, telemetry never publishes Setconfig/Processconfig, and dcmd sits idle. systemd platforms (video/STB) hid this via Before= ordering.
Fix
In registerRbusDCMEventListener() (source/ccspinterface/rbusInterface.c), replace the one-shot sync subscribe with rbusEvent_SubscribeAsync(...) + a new rbusDCMReloadSubscribeHandler callback. rbus retries the subscription in the background until dcmd registers the reload element — the same async mechanism telemetry already uses for Device.DCM.Setconfig/Processconfig. The handshake no longer depends on which daemon starts first.

	•	Entirely inside #ifdef DCMAGENT → compiled out on every non-camera build.
	•	SubscribeAsync is a strict superset of Subscribe; where the provider is already up (systemd), it completes on the first attempt → identical behavior.
	•	rbusReloadConf handler and dcmEventStatus gating unchanged.
