### PR TITLE
RDKB-66378: Implement version reporting (build tag and git revision)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,18 +39,21 @@ dnl time so the daemon can report it via --version and at startup. When the
 dnl source tree is not a git checkout (e.g. Yocto/SDK builds) fall back to
 dnl "unknown" so the build never fails.
 dnl **********************************
-T2_BUILD_TAG=`cd "$srcdir" && git describe --tags --always --dirty 2>/dev/null`
-if test -z "$T2_BUILD_TAG"; then
-    T2_BUILD_TAG="unknown"
+T2_BUILD_TAG_RAW=`cd "$srcdir" && git describe --tags --always --dirty 2>/dev/null`
+if test -z "$T2_BUILD_TAG_RAW"; then
+    T2_BUILD_TAG_RAW="unknown"
 fi
-T2_GIT_REVISION=`cd "$srcdir" && git rev-parse --short HEAD 2>/dev/null`
-if test -z "$T2_GIT_REVISION"; then
-    T2_GIT_REVISION="unknown"
+T2_GIT_REVISION_RAW=`cd "$srcdir" && git rev-parse --short HEAD 2>/dev/null`
+if test -z "$T2_GIT_REVISION_RAW"; then
+    T2_GIT_REVISION_RAW="unknown"
 fi
+
+dnl Escape for Makefile and for C string literals.
+T2_BUILD_TAG=`printf '%s' "$T2_BUILD_TAG_RAW" | sed 's/\$/$$/g; s/"/\\"/g'`
+T2_GIT_REVISION=`printf '%s' "$T2_GIT_REVISION_RAW" | sed 's/\$/$$/g; s/"/\\"/g'`
 AC_SUBST(T2_BUILD_TAG)
 AC_SUBST(T2_GIT_REVISION)
-AC_MSG_NOTICE([Telemetry build tag: $T2_BUILD_TAG, revision: $T2_GIT_REVISION])
-
+AC_MSG_NOTICE([Telemetry build tag: $T2_BUILD_TAG_RAW, revision: $T2_GIT_REVISION_RAW])
 LT_INIT
 GTEST_ENABLE_FLAG =" "
 LIBSYSWRAPPER_FLAG=" "

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,24 @@ AC_CONFIG_SRCDIR([source/protocol/rbusMethod])
 AC_CONFIG_SRCDIR([source/dcautil])
 AM_INIT_AUTOMAKE([foreign no-dist-gzip dist-bzip2 1.9])
 
+dnl **********************************
+dnl Extract build version information (git tag and revision) at configure
+dnl time so the daemon can report it via --version and at startup. When the
+dnl source tree is not a git checkout (e.g. Yocto/SDK builds) fall back to
+dnl "unknown" so the build never fails.
+dnl **********************************
+T2_BUILD_TAG=`cd "$srcdir" && git describe --tags --always --dirty 2>/dev/null`
+if test -z "$T2_BUILD_TAG"; then
+    T2_BUILD_TAG="unknown"
+fi
+T2_GIT_REVISION=`cd "$srcdir" && git rev-parse --short HEAD 2>/dev/null`
+if test -z "$T2_GIT_REVISION"; then
+    T2_GIT_REVISION="unknown"
+fi
+AC_SUBST(T2_BUILD_TAG)
+AC_SUBST(T2_GIT_REVISION)
+AC_MSG_NOTICE([Telemetry build tag: $T2_BUILD_TAG, revision: $T2_GIT_REVISION])
+
 LT_INIT
 GTEST_ENABLE_FLAG =" "
 LIBSYSWRAPPER_FLAG=" "

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -41,6 +41,7 @@ bin_PROGRAMS = telemetry2_0
 
 telemetry2_0_SOURCES = telemetry2_0.c
 telemetry2_0_CFLAGS = -DFEATURE_SUPPORT_RDKLOG -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64
+telemetry2_0_CFLAGS += -DT2_BUILD_TAG=\"$(T2_BUILD_TAG)\" -DT2_GIT_REVISION=\"$(T2_GIT_REVISION)\"
 telemetry2_0_CPPFLAGS = -fPIC -I${PKG_CONFIG_SYSROOT_DIR}$(includedir)/dbus-1.0 \
                                 -I${PKG_CONFIG_SYSROOT_DIR}$(libdir)/dbus-1.0/include \
                                 -I${PKG_CONFIG_SYSROOT_DIR}$(includedir)/ \

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -338,7 +338,7 @@ static int checkAnotherTelemetryInstance (void)
 
 static void printVersion(void)
 {
-    printf("\nTelemetry 2.0 | Tag: %s | Revision: %s\n", T2_BUILD_TAG, T2_GIT_REVISION);
+    printf("Telemetry 2.0 | Tag: %s | Revision: %s\n", T2_BUILD_TAG, T2_GIT_REVISION);
 }
 
 int main(int argc, char *argv[])

--- a/source/telemetry2_0.c
+++ b/source/telemetry2_0.c
@@ -61,6 +61,16 @@
 #define EXEC_RELOAD 12
 #define LOG_UPLOAD_ONDEMAND 29
 
+/* Build version information injected by the build system (configure.ac).
+ * Fall back to "unknown" when the values are not provided so the source
+ * always compiles standalone. */
+#ifndef T2_BUILD_TAG
+#define T2_BUILD_TAG "unknown"
+#endif
+#ifndef T2_GIT_REVISION
+#define T2_GIT_REVISION "unknown"
+#endif
+
 sigset_t blocking_signal;
 
 static bool isDebugEnabled = true;
@@ -326,11 +336,32 @@ static int checkAnotherTelemetryInstance (void)
     return 0;
 }
 
-int main()
+static void printVersion(void)
+{
+    printf("\nTelemetry 2.0 | Tag: %s | Revision: %s\n", T2_BUILD_TAG, T2_GIT_REVISION);
+}
+
+int main(int argc, char *argv[])
 {
     pid_t process_id = 0;
     pid_t sid = 0;
+
+    /* Parse CLI arguments before any daemon initialization or fork() so that
+     * a query such as --version prints and exits without acquiring the lock
+     * file or spawning a process, leaving any running daemon untouched. */
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "--version") == 0 || strcmp(argv[i], "-v") == 0)
+        {
+            printVersion();
+            return 0;
+        }
+    }
+
     LOGInit();
+
+    /* Log the build version once at daemon startup for field diagnostics. */
+    T2Info("Telemetry 2.0 | Tag: %s | Revision: %s\n", T2_BUILD_TAG, T2_GIT_REVISION);
 
     /* Abort if another instance of telemetry2_0 is already running */
     if (checkAnotherTelemetryInstance())


### PR DESCRIPTION
Reason for Change: Extract git tag and short revision at configure time and inject them as compile-time macros. Log the version once at daemon startup and add a --version CLI option that is parsed before checkAnotherTelemetryInstance() and fork(), so querying the version never touches a running daemon. Test Procedure: Refer the ticket descriptions
Risks: Medium
Priority: P0
Signed-off-by: Thamim Razith Abbas Ali <tabbas651@comcast.com>